### PR TITLE
chore: sync package-lock.json after verification install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neuroverseos/governance",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neuroverseos/governance",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "bin": {
         "neuroverse": "dist/cli/neuroverse.js"


### PR DESCRIPTION
Verified that 0.6.0 already ships the worldmodel CLI command correctly wired into the main neuroverse router. No fix needed — the earlier "Unknown command" was a stale npx cache, not a bug in the published package. This branch can be deleted.

https://claude.ai/code/session_01EQLFWsAFRExm8HGjivdYcp