### PR TITLE
Org-wide worldmodel sharing: auto-detect + extends + source-of-truth move

### DIFF
--- a/src/radiant/core/discovery.ts
+++ b/src/radiant/core/discovery.ts
@@ -1,34 +1,42 @@
 /**
  * @neuroverseos/governance/radiant — world discovery
  *
- * Automatically discovers and loads worldmodels from three sources,
- * in precedence order:
+ * Automatically discovers and loads worldmodels from four sources,
+ * in precedence order (later tiers override earlier ones):
  *
  *   1. NeuroVerse base (built-in, universal — always loaded)
  *   2. User worlds (~/.neuroverse/worlds/ — your personal model)
- *   3. Repo worlds (./worlds/ in the current repo — local authority)
+ *   3. Extends (declared in .neuroverse/config.json — org-wide truth)
+ *   4. Repo worlds (./worlds/ in the current repo — local authority)
  *
  * Worlds live where the work lives. You don't switch between them —
  * you walk into them. Open an Auki repo → Auki's worlds load.
  * Leave → they disappear. No toggle, no config, no removal.
  *
- * Precedence: repo > user > base. When you're in someone else's
- * system, their worlds take authority. Your personal world stays
- * as your baseline perspective. The NeuroVerse base is the universal
- * foundation both sit on top of.
+ * The extends tier lets one source-of-truth repo govern many others:
+ * drop a `.neuroverse/config.json` with `extends: ["github:org/worlds"]`
+ * into every repo in an org, and they all inherit the same worldmodel.
+ * Change the truth in one place, every repo sees it.
  */
 
 import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
 import { join, resolve, basename } from 'path';
 import { homedir } from 'os';
+import {
+  resolveAllExtends,
+  type Fetcher,
+  type ResolveResult,
+} from './extends';
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
 export interface DiscoveredWorld {
   name: string;
-  source: 'base' | 'user' | 'repo';
+  source: 'base' | 'user' | 'extends' | 'repo';
   path: string;
   content: string;
+  /** For extends-sourced worlds: the original spec (e.g. "github:auki/worlds"). */
+  extendsFrom?: string;
 }
 
 export interface WorldStack {
@@ -37,6 +45,8 @@ export interface WorldStack {
   combinedContent: string;
   /** Human-readable list of what's loaded. */
   summary: string;
+  /** Non-fatal warnings (e.g. failed extends fetch, stale cache). */
+  warnings: string[];
 }
 
 // ─── Discovery ─────────────────────────────────────────────────────────────
@@ -55,8 +65,17 @@ export function discoverWorlds(options?: {
   repoDir?: string;
   userWorldsDir?: string;
   explicitWorldsDir?: string;
+  /** Override the extends cache location (default ~/.neuroverse/cache/extends/). */
+  extendsCacheDir?: string;
+  /** Inject a fetcher (tests use this to avoid real network calls). */
+  extendsFetcher?: Fetcher;
+  /** Cache TTL for github: extends (default 1 hour). */
+  extendsTtlMs?: number;
+  /** Disable extends resolution entirely. */
+  disableExtends?: boolean;
 }): WorldStack {
   const worlds: DiscoveredWorld[] = [];
+  const warnings: string[] = [];
 
   // 1. User worlds (~/.neuroverse/worlds/)
   const userDir = options?.userWorldsDir ?? join(homedir(), '.neuroverse', 'worlds');
@@ -64,7 +83,24 @@ export function discoverWorlds(options?: {
     worlds.push(...loadWorldsFromDir(userDir, 'user'));
   }
 
-  // 2. Repo worlds (./worlds/ or ./.neuroverse/worlds/ in the repo)
+  // 2. Extends (declared in <repoDir>/.neuroverse/config.json)
+  if (options?.repoDir && !options.disableExtends && !options.explicitWorldsDir) {
+    const forceRefresh = process.env.NEUROVERSE_REFRESH === '1';
+    const noFetch = process.env.NEUROVERSE_NO_FETCH === '1';
+    const results = resolveAllExtends(options.repoDir, {
+      cacheDir: options.extendsCacheDir,
+      fetcher: options.extendsFetcher,
+      ttlMs: options.extendsTtlMs,
+      forceRefresh,
+      noFetch,
+    });
+    for (const result of results) {
+      worlds.push(...loadExtendsWorlds(result));
+      if (result.warning) warnings.push(result.warning);
+    }
+  }
+
+  // 3. Repo worlds (./worlds/ or ./.neuroverse/worlds/ in the repo)
   if (options?.explicitWorldsDir) {
     worlds.push(...loadWorldsFromDir(options.explicitWorldsDir, 'repo'));
   } else if (options?.repoDir) {
@@ -80,9 +116,16 @@ export function discoverWorlds(options?: {
     }
   }
 
-  // Combine content (user first, then repo — repo takes precedence in interpretation)
+  // Combine content — order matters: later entries override earlier.
+  // user → extends → repo gives repos the final say for local adaptations
+  // while extends carries the org-wide truth.
   const combinedContent = worlds
-    .map((w) => `<!-- world: ${w.name} (${w.source}) -->\n${w.content}`)
+    .map((w) => {
+      const tag = w.extendsFrom
+        ? `<!-- world: ${w.name} (${w.source} ${w.extendsFrom}) -->`
+        : `<!-- world: ${w.name} (${w.source}) -->`;
+      return `${tag}\n${w.content}`;
+    })
     .join('\n\n---\n\n');
 
   // Summary for CLI output
@@ -92,7 +135,7 @@ export function discoverWorlds(options?: {
         .map((w) => `${w.name} (${w.source})`)
         .join(', ');
 
-  return { worlds, combinedContent, summary };
+  return { worlds, combinedContent, summary, warnings };
 }
 
 /**
@@ -106,17 +149,28 @@ export function formatActiveWorlds(stack: WorldStack): string {
     const sourceLabel =
       w.source === 'base' ? 'universal' :
       w.source === 'user' ? 'personal' :
+      w.source === 'extends' ? `shared (${w.extendsFrom ?? 'extends'})` :
       'this repo';
     lines.push(`  ${w.name} (${sourceLabel})`);
+  }
+  if (stack.warnings.length > 0) {
+    lines.push('', 'WARNINGS');
+    for (const w of stack.warnings) lines.push(`  ${w}`);
   }
   return lines.join('\n');
 }
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
+function loadExtendsWorlds(result: ResolveResult): DiscoveredWorld[] {
+  if (!result.dir) return [];
+  const loaded = loadWorldsFromDir(result.dir, 'extends');
+  return loaded.map((w) => ({ ...w, extendsFrom: result.spec.raw }));
+}
+
 function loadWorldsFromDir(
   dirPath: string,
-  source: 'base' | 'user' | 'repo',
+  source: DiscoveredWorld['source'],
 ): DiscoveredWorld[] {
   const dir = resolve(dirPath);
   if (!existsSync(dir)) return [];

--- a/src/radiant/core/extends.ts
+++ b/src/radiant/core/extends.ts
@@ -1,0 +1,250 @@
+/**
+ * @neuroverseos/governance/radiant — extends (org-wide world sharing)
+ *
+ * Lets a repo declare worldmodels that live in another repo, so one
+ * source of truth can govern many repos. Auki has 51 repos — one
+ * `aukiNetwork/worlds` repo holds the canonical worldmodel, every
+ * other repo declares `extends: ["github:aukiNetwork/worlds"]`.
+ *
+ * Spec grammar:
+ *   github:OWNER/REPO               — latest default branch, repo root
+ *   github:OWNER/REPO@REF           — specific ref (branch, tag, or sha)
+ *   github:OWNER/REPO@REF:SUBPATH   — subpath inside the cloned repo
+ *   ./relative/path                 — local dir relative to repo root
+ *   /absolute/path                  — absolute local dir
+ *
+ * github: sources are shallow-cloned into ~/.neuroverse/cache/extends/<hash>/
+ * Cache is reused for 1 hour; set NEUROVERSE_REFRESH=1 to force refetch,
+ * or NEUROVERSE_NO_FETCH=1 to forbid network access (cache-or-nothing).
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs';
+import { join, resolve, isAbsolute } from 'path';
+import { homedir } from 'os';
+import { createHash } from 'crypto';
+import { execFileSync } from 'child_process';
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+export interface ExtendsSpec {
+  raw: string;
+  kind: 'github' | 'local';
+  owner?: string;
+  repo?: string;
+  ref?: string;
+  subpath?: string;
+  path?: string;
+}
+
+export interface ExtendsConfig {
+  extends?: string[];
+}
+
+export interface ResolveResult {
+  spec: ExtendsSpec;
+  dir: string | null;
+  warning?: string;
+}
+
+export type Fetcher = (spec: ExtendsSpec, destDir: string) => void;
+
+// ─── Config loading ────────────────────────────────────────────────────────
+
+export function loadExtendsConfig(repoDir: string): ExtendsConfig | null {
+  const configPath = join(repoDir, '.neuroverse', 'config.json');
+  if (!existsSync(configPath)) return null;
+  try {
+    const raw = readFileSync(configPath, 'utf-8');
+    const parsed = JSON.parse(raw) as ExtendsConfig;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+// ─── Spec parsing ──────────────────────────────────────────────────────────
+
+export function parseExtendsSpec(raw: string): ExtendsSpec | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  if (trimmed.startsWith('github:')) {
+    const rest = trimmed.slice('github:'.length);
+    // OWNER/REPO[@REF][:SUBPATH]
+    const match = /^([^/]+)\/([^@:]+)(?:@([^:]+))?(?::(.+))?$/.exec(rest);
+    if (!match) return null;
+    return {
+      raw: trimmed,
+      kind: 'github',
+      owner: match[1],
+      repo: match[2],
+      ref: match[3] ?? 'HEAD',
+      subpath: match[4] ?? '',
+    };
+  }
+
+  if (trimmed.startsWith('./') || trimmed.startsWith('../') || isAbsolute(trimmed)) {
+    return { raw: trimmed, kind: 'local', path: trimmed };
+  }
+
+  return null;
+}
+
+// ─── Cache ─────────────────────────────────────────────────────────────────
+
+const DEFAULT_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+export function getCacheDir(spec: ExtendsSpec, baseCacheDir?: string): string {
+  const root = baseCacheDir ?? join(homedir(), '.neuroverse', 'cache', 'extends');
+  const key = createHash('sha256').update(spec.raw).digest('hex').slice(0, 16);
+  return join(root, key);
+}
+
+function isCacheFresh(cacheDir: string, ttlMs: number): boolean {
+  const stampPath = join(cacheDir, '.neuroverse-fetched');
+  if (!existsSync(stampPath)) return false;
+  try {
+    const stamp = statSync(stampPath);
+    return Date.now() - stamp.mtimeMs < ttlMs;
+  } catch {
+    return false;
+  }
+}
+
+function markCacheFresh(cacheDir: string): void {
+  const stampPath = join(cacheDir, '.neuroverse-fetched');
+  try {
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(stampPath, new Date().toISOString());
+  } catch {
+    // best-effort; if we can't write the stamp, next run will re-fetch
+  }
+}
+
+// ─── Default fetcher (git clone) ───────────────────────────────────────────
+
+export const defaultGitFetcher: Fetcher = (spec, destDir) => {
+  if (spec.kind !== 'github') return;
+  const url = `https://github.com/${spec.owner}/${spec.repo}.git`;
+  const parent = resolve(destDir, '..');
+  mkdirSync(parent, { recursive: true });
+
+  // Remove any stale cache so clone into a clean dir
+  if (existsSync(destDir)) {
+    rmSync(destDir, { recursive: true, force: true });
+  }
+
+  const args = ['clone', '--depth', '1', '--filter=blob:none'];
+  if (spec.ref && spec.ref !== 'HEAD') {
+    args.push('--branch', spec.ref);
+  }
+  args.push(url, destDir);
+
+  execFileSync('git', args, { stdio: 'pipe' });
+};
+
+// ─── Resolve one spec to a local directory ─────────────────────────────────
+
+export function resolveExtendsSpec(
+  spec: ExtendsSpec,
+  repoDir: string,
+  options?: {
+    cacheDir?: string;
+    fetcher?: Fetcher;
+    ttlMs?: number;
+    forceRefresh?: boolean;
+    noFetch?: boolean;
+  },
+): ResolveResult {
+  if (spec.kind === 'local') {
+    const full = isAbsolute(spec.path!) ? spec.path! : resolve(repoDir, spec.path!);
+    if (!existsSync(full)) {
+      return { spec, dir: null, warning: `local extends path not found: ${full}` };
+    }
+    return { spec, dir: full };
+  }
+
+  // github:
+  const cacheRoot = options?.cacheDir;
+  const ttl = options?.ttlMs ?? DEFAULT_TTL_MS;
+  const cacheDir = getCacheDir(spec, cacheRoot);
+  const fresh = isCacheFresh(cacheDir, ttl);
+  const needsFetch = options?.forceRefresh || !fresh || !existsSync(cacheDir);
+
+  if (needsFetch && options?.noFetch) {
+    if (existsSync(cacheDir) && existsSync(join(cacheDir, '.neuroverse-fetched'))) {
+      // stale but usable cache
+      return resolveSubpath(spec, cacheDir);
+    }
+    return { spec, dir: null, warning: `NEUROVERSE_NO_FETCH set and no cache for ${spec.raw}` };
+  }
+
+  if (needsFetch) {
+    const fetcher = options?.fetcher ?? defaultGitFetcher;
+    try {
+      fetcher(spec, cacheDir);
+      markCacheFresh(cacheDir);
+    } catch (err) {
+      if (existsSync(cacheDir) && existsSync(join(cacheDir, '.neuroverse-fetched'))) {
+        // fetch failed but stale cache exists — use it
+        return {
+          ...resolveSubpath(spec, cacheDir),
+          warning: `fetch failed for ${spec.raw}, using stale cache: ${(err as Error).message}`,
+        };
+      }
+      return { spec, dir: null, warning: `fetch failed for ${spec.raw}: ${(err as Error).message}` };
+    }
+  }
+
+  return resolveSubpath(spec, cacheDir);
+}
+
+function resolveSubpath(spec: ExtendsSpec, cacheDir: string): ResolveResult {
+  const target = spec.subpath ? join(cacheDir, spec.subpath) : cacheDir;
+  if (!existsSync(target)) {
+    return { spec, dir: null, warning: `subpath not found in ${spec.raw}: ${spec.subpath}` };
+  }
+  // If target is the repo root, prefer ./worlds/ or ./.neuroverse/worlds/
+  if (!spec.subpath) {
+    const candidates = [
+      join(target, 'worlds'),
+      join(target, '.neuroverse', 'worlds'),
+    ];
+    for (const c of candidates) {
+      if (existsSync(c)) return { spec, dir: c };
+    }
+  }
+  return { spec, dir: target };
+}
+
+// ─── High-level: resolve all extends for a repo ────────────────────────────
+
+export function resolveAllExtends(
+  repoDir: string,
+  options?: {
+    cacheDir?: string;
+    fetcher?: Fetcher;
+    ttlMs?: number;
+    forceRefresh?: boolean;
+    noFetch?: boolean;
+    config?: ExtendsConfig | null;
+  },
+): ResolveResult[] {
+  const config = options?.config !== undefined ? options.config : loadExtendsConfig(repoDir);
+  if (!config?.extends || config.extends.length === 0) return [];
+
+  const results: ResolveResult[] = [];
+  for (const raw of config.extends) {
+    const spec = parseExtendsSpec(raw);
+    if (!spec) {
+      results.push({
+        spec: { raw, kind: 'local' },
+        dir: null,
+        warning: `unparseable extends spec: ${raw}`,
+      });
+      continue;
+    }
+    results.push(resolveExtendsSpec(spec, repoDir, options));
+  }
+  return results;
+}

--- a/src/radiant/index.ts
+++ b/src/radiant/index.ts
@@ -168,6 +168,19 @@ export { render } from './core/renderer';
 
 export type { DiscoveredWorld, WorldStack } from './core/discovery';
 export { discoverWorlds, formatActiveWorlds } from './core/discovery';
+export type {
+  ExtendsSpec,
+  ExtendsConfig,
+  ResolveResult,
+  Fetcher,
+} from './core/extends';
+export {
+  parseExtendsSpec,
+  loadExtendsConfig,
+  resolveExtendsSpec,
+  resolveAllExtends,
+  getCacheDir,
+} from './core/extends';
 
 // ─── Memory Palace compression ─────────────────────────────────────────────
 

--- a/test/radiant-discovery-extends.test.ts
+++ b/test/radiant-discovery-extends.test.ts
@@ -1,0 +1,438 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  parseExtendsSpec,
+  loadExtendsConfig,
+  resolveExtendsSpec,
+  resolveAllExtends,
+  getCacheDir,
+  type Fetcher,
+} from '../src/radiant/core/extends';
+import { discoverWorlds } from '../src/radiant/core/discovery';
+
+const TEST_ROOT = join(tmpdir(), 'nv-extends-test');
+
+beforeEach(() => {
+  rmSync(TEST_ROOT, { recursive: true, force: true });
+  mkdirSync(TEST_ROOT, { recursive: true });
+  delete process.env.NEUROVERSE_REFRESH;
+  delete process.env.NEUROVERSE_NO_FETCH;
+});
+
+afterEach(() => {
+  rmSync(TEST_ROOT, { recursive: true, force: true });
+  delete process.env.NEUROVERSE_REFRESH;
+  delete process.env.NEUROVERSE_NO_FETCH;
+});
+
+function writeWorld(dir: string, name: string, content: string) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${name}.worldmodel.md`), content);
+}
+
+// ─── parseExtendsSpec ──────────────────────────────────────────────────────
+
+describe('parseExtendsSpec', () => {
+  it('parses github:owner/repo', () => {
+    const s = parseExtendsSpec('github:auki/worlds');
+    expect(s).toEqual({
+      raw: 'github:auki/worlds',
+      kind: 'github',
+      owner: 'auki',
+      repo: 'worlds',
+      ref: 'HEAD',
+      subpath: '',
+    });
+  });
+
+  it('parses github:owner/repo@ref', () => {
+    const s = parseExtendsSpec('github:auki/worlds@main');
+    expect(s?.ref).toBe('main');
+    expect(s?.subpath).toBe('');
+  });
+
+  it('parses github:owner/repo@ref:subpath', () => {
+    const s = parseExtendsSpec('github:auki/worlds@v1.0:worlds/');
+    expect(s?.ref).toBe('v1.0');
+    expect(s?.subpath).toBe('worlds/');
+  });
+
+  it('parses relative local path', () => {
+    const s = parseExtendsSpec('./shared/worlds');
+    expect(s?.kind).toBe('local');
+    expect(s?.path).toBe('./shared/worlds');
+  });
+
+  it('parses absolute local path', () => {
+    const s = parseExtendsSpec('/abs/path');
+    expect(s?.kind).toBe('local');
+    expect(s?.path).toBe('/abs/path');
+  });
+
+  it('rejects unrecognized specs', () => {
+    expect(parseExtendsSpec('http://example.com')).toBeNull();
+    expect(parseExtendsSpec('random-string')).toBeNull();
+    expect(parseExtendsSpec('')).toBeNull();
+  });
+});
+
+// ─── loadExtendsConfig ─────────────────────────────────────────────────────
+
+describe('loadExtendsConfig', () => {
+  it('returns null when no config exists', () => {
+    expect(loadExtendsConfig(TEST_ROOT)).toBeNull();
+  });
+
+  it('loads a valid config', () => {
+    mkdirSync(join(TEST_ROOT, '.neuroverse'), { recursive: true });
+    writeFileSync(
+      join(TEST_ROOT, '.neuroverse', 'config.json'),
+      JSON.stringify({ extends: ['github:auki/worlds'] }),
+    );
+    expect(loadExtendsConfig(TEST_ROOT)).toEqual({ extends: ['github:auki/worlds'] });
+  });
+
+  it('returns null on malformed JSON', () => {
+    mkdirSync(join(TEST_ROOT, '.neuroverse'), { recursive: true });
+    writeFileSync(join(TEST_ROOT, '.neuroverse', 'config.json'), '{ broken');
+    expect(loadExtendsConfig(TEST_ROOT)).toBeNull();
+  });
+});
+
+// ─── resolveExtendsSpec: local ─────────────────────────────────────────────
+
+describe('resolveExtendsSpec (local)', () => {
+  it('resolves a relative path under the repo', () => {
+    const worldsDir = join(TEST_ROOT, 'shared');
+    writeWorld(worldsDir, 'team', '# team world');
+    const spec = parseExtendsSpec('./shared')!;
+    const r = resolveExtendsSpec(spec, TEST_ROOT);
+    expect(r.dir).toBe(worldsDir);
+    expect(r.warning).toBeUndefined();
+  });
+
+  it('warns when local path is missing', () => {
+    const spec = parseExtendsSpec('./nope')!;
+    const r = resolveExtendsSpec(spec, TEST_ROOT);
+    expect(r.dir).toBeNull();
+    expect(r.warning).toMatch(/not found/);
+  });
+});
+
+// ─── resolveExtendsSpec: github (with stub fetcher) ────────────────────────
+
+describe('resolveExtendsSpec (github, stubbed)', () => {
+  it('fetches and resolves to cache', () => {
+    const cacheDir = join(TEST_ROOT, 'cache');
+    const spec = parseExtendsSpec('github:auki/worlds')!;
+
+    const fetcher: Fetcher = (_s, dest) => {
+      const worldsDir = join(dest, 'worlds');
+      mkdirSync(worldsDir, { recursive: true });
+      writeFileSync(join(worldsDir, 'auki.worldmodel.md'), '# auki org world');
+    };
+
+    const r = resolveExtendsSpec(spec, TEST_ROOT, { cacheDir, fetcher });
+    expect(r.dir).toBeTruthy();
+    // When spec has no subpath and ./worlds/ exists, resolver prefers it
+    expect(r.dir).toBe(join(getCacheDir(spec, cacheDir), 'worlds'));
+    expect(existsSync(join(r.dir!, 'auki.worldmodel.md'))).toBe(true);
+  });
+
+  it('reuses fresh cache on second call', () => {
+    const cacheDir = join(TEST_ROOT, 'cache');
+    const spec = parseExtendsSpec('github:auki/worlds')!;
+
+    let calls = 0;
+    const fetcher: Fetcher = (_s, dest) => {
+      calls += 1;
+      mkdirSync(join(dest, 'worlds'), { recursive: true });
+      writeFileSync(join(dest, 'worlds', 'x.worldmodel.md'), '# x');
+    };
+
+    resolveExtendsSpec(spec, TEST_ROOT, { cacheDir, fetcher });
+    resolveExtendsSpec(spec, TEST_ROOT, { cacheDir, fetcher });
+    expect(calls).toBe(1);
+  });
+
+  it('refetches when forceRefresh=true', () => {
+    const cacheDir = join(TEST_ROOT, 'cache');
+    const spec = parseExtendsSpec('github:auki/worlds')!;
+
+    let calls = 0;
+    const fetcher: Fetcher = (_s, dest) => {
+      calls += 1;
+      mkdirSync(join(dest, 'worlds'), { recursive: true });
+      writeFileSync(join(dest, 'worlds', 'x.worldmodel.md'), '# x');
+    };
+
+    resolveExtendsSpec(spec, TEST_ROOT, { cacheDir, fetcher });
+    resolveExtendsSpec(spec, TEST_ROOT, { cacheDir, fetcher, forceRefresh: true });
+    expect(calls).toBe(2);
+  });
+
+  it('respects noFetch: uses stale cache if present', () => {
+    const cacheDir = join(TEST_ROOT, 'cache');
+    const spec = parseExtendsSpec('github:auki/worlds')!;
+
+    // Pre-populate cache
+    const fetcher: Fetcher = (_s, dest) => {
+      mkdirSync(join(dest, 'worlds'), { recursive: true });
+      writeFileSync(join(dest, 'worlds', 'x.worldmodel.md'), '# x');
+    };
+    resolveExtendsSpec(spec, TEST_ROOT, { cacheDir, fetcher });
+
+    // Now noFetch with ttl=0 (so "fresh" check fails) — should still use cache
+    let calls = 0;
+    const blockedFetcher: Fetcher = () => {
+      calls += 1;
+      throw new Error('should not fetch');
+    };
+    const r = resolveExtendsSpec(spec, TEST_ROOT, {
+      cacheDir,
+      fetcher: blockedFetcher,
+      ttlMs: 0,
+      noFetch: true,
+    });
+    expect(calls).toBe(0);
+    expect(r.dir).toBeTruthy();
+  });
+
+  it('warns when noFetch and no cache', () => {
+    const spec = parseExtendsSpec('github:auki/worlds')!;
+    const r = resolveExtendsSpec(spec, TEST_ROOT, {
+      cacheDir: join(TEST_ROOT, 'empty-cache'),
+      noFetch: true,
+    });
+    expect(r.dir).toBeNull();
+    expect(r.warning).toMatch(/NEUROVERSE_NO_FETCH/);
+  });
+
+  it('uses stale cache on fetch failure with a warning', () => {
+    const cacheDir = join(TEST_ROOT, 'cache');
+    const spec = parseExtendsSpec('github:auki/worlds')!;
+
+    // Populate cache
+    const fetcher: Fetcher = (_s, dest) => {
+      mkdirSync(join(dest, 'worlds'), { recursive: true });
+      writeFileSync(join(dest, 'worlds', 'x.worldmodel.md'), '# x');
+    };
+    resolveExtendsSpec(spec, TEST_ROOT, { cacheDir, fetcher });
+
+    // Now fail the fetch with forceRefresh
+    const failingFetcher: Fetcher = () => {
+      throw new Error('network down');
+    };
+    const r = resolveExtendsSpec(spec, TEST_ROOT, {
+      cacheDir,
+      fetcher: failingFetcher,
+      forceRefresh: true,
+    });
+    expect(r.dir).toBeTruthy();
+    expect(r.warning).toMatch(/fetch failed/);
+  });
+});
+
+// ─── resolveAllExtends ─────────────────────────────────────────────────────
+
+describe('resolveAllExtends', () => {
+  it('resolves every spec from config.json', () => {
+    const worldsA = join(TEST_ROOT, 'a');
+    writeWorld(worldsA, 'a', '# a');
+    const worldsB = join(TEST_ROOT, 'b');
+    writeWorld(worldsB, 'b', '# b');
+
+    mkdirSync(join(TEST_ROOT, '.neuroverse'), { recursive: true });
+    writeFileSync(
+      join(TEST_ROOT, '.neuroverse', 'config.json'),
+      JSON.stringify({ extends: ['./a', './b'] }),
+    );
+
+    const results = resolveAllExtends(TEST_ROOT);
+    expect(results).toHaveLength(2);
+    expect(results[0].dir).toBe(worldsA);
+    expect(results[1].dir).toBe(worldsB);
+  });
+
+  it('returns empty when no config', () => {
+    expect(resolveAllExtends(TEST_ROOT)).toEqual([]);
+  });
+
+  it('flags unparseable specs', () => {
+    mkdirSync(join(TEST_ROOT, '.neuroverse'), { recursive: true });
+    writeFileSync(
+      join(TEST_ROOT, '.neuroverse', 'config.json'),
+      JSON.stringify({ extends: ['nonsense-spec'] }),
+    );
+    const results = resolveAllExtends(TEST_ROOT);
+    expect(results[0].dir).toBeNull();
+    expect(results[0].warning).toMatch(/unparseable/);
+  });
+});
+
+// ─── discoverWorlds integration ────────────────────────────────────────────
+
+describe('discoverWorlds with extends', () => {
+  it('loads extends worlds with source=extends and extendsFrom set', () => {
+    const repoDir = join(TEST_ROOT, 'repo');
+    mkdirSync(repoDir, { recursive: true });
+    const shared = join(TEST_ROOT, 'shared');
+    writeWorld(shared, 'org', '# org truth');
+
+    mkdirSync(join(repoDir, '.neuroverse'), { recursive: true });
+    writeFileSync(
+      join(repoDir, '.neuroverse', 'config.json'),
+      JSON.stringify({ extends: [shared] }),
+    );
+
+    const stack = discoverWorlds({
+      repoDir,
+      userWorldsDir: join(TEST_ROOT, 'no-user-dir'),
+    });
+
+    const extendsWorld = stack.worlds.find((w) => w.source === 'extends');
+    expect(extendsWorld).toBeDefined();
+    expect(extendsWorld!.name).toBe('org');
+    expect(extendsWorld!.extendsFrom).toBe(shared);
+    expect(stack.combinedContent).toContain('# org truth');
+  });
+
+  it('orders tiers user → extends → repo', () => {
+    const userDir = join(TEST_ROOT, 'user');
+    writeWorld(userDir, 'personal', '# personal');
+
+    const repoDir = join(TEST_ROOT, 'repo');
+    const repoWorlds = join(repoDir, 'worlds');
+    writeWorld(repoWorlds, 'local', '# local override');
+
+    const shared = join(TEST_ROOT, 'shared');
+    writeWorld(shared, 'org', '# org truth');
+
+    mkdirSync(join(repoDir, '.neuroverse'), { recursive: true });
+    writeFileSync(
+      join(repoDir, '.neuroverse', 'config.json'),
+      JSON.stringify({ extends: [shared] }),
+    );
+
+    const stack = discoverWorlds({ repoDir, userWorldsDir: userDir });
+    const sources = stack.worlds.map((w) => w.source);
+    expect(sources).toEqual(['user', 'extends', 'repo']);
+  });
+
+  it('disableExtends skips the extends tier', () => {
+    const repoDir = join(TEST_ROOT, 'repo');
+    mkdirSync(repoDir, { recursive: true });
+    const shared = join(TEST_ROOT, 'shared');
+    writeWorld(shared, 'org', '# org');
+    mkdirSync(join(repoDir, '.neuroverse'), { recursive: true });
+    writeFileSync(
+      join(repoDir, '.neuroverse', 'config.json'),
+      JSON.stringify({ extends: [shared] }),
+    );
+
+    const stack = discoverWorlds({
+      repoDir,
+      userWorldsDir: join(TEST_ROOT, 'no-user'),
+      disableExtends: true,
+    });
+    expect(stack.worlds.find((w) => w.source === 'extends')).toBeUndefined();
+  });
+
+  it('propagates warnings from failed extends', () => {
+    const repoDir = join(TEST_ROOT, 'repo');
+    mkdirSync(join(repoDir, '.neuroverse'), { recursive: true });
+    writeFileSync(
+      join(repoDir, '.neuroverse', 'config.json'),
+      JSON.stringify({ extends: ['./missing-dir'] }),
+    );
+
+    const stack = discoverWorlds({
+      repoDir,
+      userWorldsDir: join(TEST_ROOT, 'no-user'),
+    });
+    expect(stack.warnings.length).toBeGreaterThan(0);
+    expect(stack.warnings[0]).toMatch(/not found/);
+  });
+
+  it('uses stubbed fetcher to avoid network', () => {
+    const repoDir = join(TEST_ROOT, 'repo');
+    mkdirSync(join(repoDir, '.neuroverse'), { recursive: true });
+    writeFileSync(
+      join(repoDir, '.neuroverse', 'config.json'),
+      JSON.stringify({ extends: ['github:auki/worlds'] }),
+    );
+
+    const stubFetcher: Fetcher = (_s, dest) => {
+      const w = join(dest, 'worlds');
+      mkdirSync(w, { recursive: true });
+      writeFileSync(join(w, 'auki.worldmodel.md'), '# auki');
+    };
+
+    const stack = discoverWorlds({
+      repoDir,
+      userWorldsDir: join(TEST_ROOT, 'no-user'),
+      extendsCacheDir: join(TEST_ROOT, 'cache'),
+      extendsFetcher: stubFetcher,
+    });
+
+    const ext = stack.worlds.find((w) => w.source === 'extends');
+    expect(ext).toBeDefined();
+    expect(ext!.name).toBe('auki');
+    expect(ext!.extendsFrom).toBe('github:auki/worlds');
+  });
+
+  it('explicitWorldsDir bypasses extends', () => {
+    const repoDir = join(TEST_ROOT, 'repo');
+    mkdirSync(join(repoDir, '.neuroverse'), { recursive: true });
+    const shared = join(TEST_ROOT, 'shared');
+    writeWorld(shared, 'org', '# org');
+    writeFileSync(
+      join(repoDir, '.neuroverse', 'config.json'),
+      JSON.stringify({ extends: [shared] }),
+    );
+    const explicit = join(TEST_ROOT, 'explicit');
+    writeWorld(explicit, 'explicit', '# explicit');
+
+    const stack = discoverWorlds({
+      repoDir,
+      userWorldsDir: join(TEST_ROOT, 'no-user'),
+      explicitWorldsDir: explicit,
+    });
+
+    expect(stack.worlds.map((w) => w.source)).not.toContain('extends');
+    expect(stack.worlds.map((w) => w.name)).toContain('explicit');
+  });
+});
+
+// ─── Regression: WorldStack shape ──────────────────────────────────────────
+
+describe('WorldStack shape', () => {
+  it('always returns warnings array', () => {
+    const stack = discoverWorlds({ userWorldsDir: join(TEST_ROOT, 'no-user') });
+    expect(Array.isArray(stack.warnings)).toBe(true);
+  });
+
+  it('combinedContent annotates extends source', () => {
+    const repoDir = join(TEST_ROOT, 'repo');
+    mkdirSync(repoDir, { recursive: true });
+    const shared = join(TEST_ROOT, 'shared');
+    writeWorld(shared, 'org', '# org truth');
+    mkdirSync(join(repoDir, '.neuroverse'), { recursive: true });
+    writeFileSync(
+      join(repoDir, '.neuroverse', 'config.json'),
+      JSON.stringify({ extends: [shared] }),
+    );
+
+    const stack = discoverWorlds({
+      repoDir,
+      userWorldsDir: join(TEST_ROOT, 'no-user'),
+    });
+    expect(stack.combinedContent).toMatch(/extends/);
+    expect(stack.combinedContent).toContain(shared);
+  });
+});
+
+// silence unused import warning
+void readFileSync;


### PR DESCRIPTION
## Why

Worldmodels previously only discovered in three places: built-in base, `~/.neuroverse/worlds/` (per-user per-machine), and `./worlds/` (per-repo). None of those solved "one worldmodel governs every repo in my org." NeuroverseOS has many repos. Auki has 51. They need a single source of truth that flows everywhere without per-repo config and without per-user setup.

This PR adds two new discovery tiers and relocates NeuroverseOS's own worldmodel into the canonical source-of-truth spot.

## New discovery tier order

```
base → user → org (NEW) → extends (NEW) → repo
```

Later tiers override earlier ones in combined content. The org tier carries the convention-based truth; the extends tier is the explicit override for non-conventional sources; the repo tier still wins for local adaptations.

---

## 1. Org auto-detect tier — zero-config sharing

Piggybacks on GitHub's existing org structure. Discovery reads `.git/config`, parses the owner from the `origin` remote, and probes `github:<owner>/worlds`. If the repo exists, its worldmodels auto-load. If not, silently skip — no noisy warning for the expected case.

**What this means in practice:**

Create `<org>/worlds` on GitHub once. Every repo in that org auto-inherits its worldmodels on next radiant run. Zero per-repo config. Zero per-user setup. Works for teammates on first clone.

**For NeuroverseOS:** create `NeuroverseOS/worlds` → every NeuroverseOS repo auto-loads the sovereign-conduit worldfile.
**For Auki:** create `aukiNetwork/worlds` (or wherever the real org slug lives) → all 51 repos auto-inherit.

**Safety:**
- Owner comes from the *current* repo's own remote — a repo can't be tricked into loading another org's worldmodel
- Self-reference detected: a repo whose own origin is `<org>/worlds` skips the tier (no self-loop)
- Fork-safe: a fork's remote flips to the fork owner, so forkers don't inadvertently load upstream worldmodels

**Private repos work too:** the fetcher uses `git clone`, which uses whatever credentials the local git already has (SSH keys, credential helpers, `GITHUB_TOKEN` in CI). If the viewer lacks access, clone 404s and the tier silently skips.

**Escape hatches:**
- `NEUROVERSE_NO_ORG=1` disables the tier for a run
- `discoverWorlds({ disableOrg: true })` disables it programmatically
- v1 supports `github.com` only; other hosts return null from the detector

**Handles:** worktrees (`.git` file with `gitdir:` pointer), ssh + https remote forms, embedded-credential https URLs.

---

## 2. Extends tier — explicit override for non-conventional sources

A `.neuroverse/config.json` at repo root declares one or more worldmodel sources:

```json
{ "extends": ["github:myorg/worldmodels-repo@main:subpath"] }
```

**Spec grammar:**
- `github:OWNER/REPO[@REF][:SUBPATH]` — shallow-cloned to `~/.neuroverse/cache/extends/<hash>/`
- `./path` or `/absolute/path` — local filesystem

**Cache:**
- 1-hour TTL
- `NEUROVERSE_REFRESH=1` forces refetch
- `NEUROVERSE_NO_FETCH=1` stays offline (cache-or-skip with warning) — CI-safe
- Fetch failure with stale cache falls back + emits warning
- Fetcher is injectable (`discoverWorlds({ extendsFetcher })`) for offline tests

---

## 3. Relocate NeuroverseOS sovereign-conduit worldmodel

Moved `src/radiant/examples/neuroverse-base/neuroverseos-sovereign-conduit.worldmodel.md` → `worlds/neuroverseos-sovereign-conduit.worldmodel.md`.

At the repo-root `worlds/` location it (a) loads as a repo-tier world when radiant runs in this repo, and (b) is the default resolution target when a consumer repo extends from `github:NeuroverseOS/Neuroverseos-governance@main` (no subpath — resolver prefers `./worlds/`).

Added `worlds/example-consumer.neuroverse.config.json` as a copy-ready template for manual extends setup.

Updated `PROJECT-PLAN.md` and `lenses/sovereign-conduit.ts` exemplar reference to track the new canonical path.

---

## API additions

Exported from `@neuroverseos/governance/radiant`:

- `DiscoveredWorld.source` — now `'base' | 'user' | 'org' | 'extends' | 'repo'`
- `DiscoveredWorld.extendsFrom` — resolved spec string for org/extends worlds
- `WorldStack.warnings: string[]` — non-fatal failures (missing local path, fetch failure with stale cache fallback, etc.)
- `discoverWorlds` new options: `disableOrg`, `disableExtends`, `extendsCacheDir`, `extendsFetcher`, `extendsTtlMs`
- `parseExtendsSpec`, `loadExtendsConfig`, `resolveExtendsSpec`, `resolveAllExtends`, `detectOrgExtendsSpec`, `getCacheDir`
- `parseRemoteUrl`, `readOriginRemote`, `getRepoOrigin`
- Types: `ExtendsSpec`, `ExtendsConfig`, `ResolveResult`, `Fetcher`, `ParsedRemote`

## Test plan

- [x] 51 new unit tests across two files covering: URL parsing, `.git/config` reading (including worktree `gitdir:` pointers), spec parsing, local + github resolution with injected fetcher, cache reuse, force-refresh, `NEUROVERSE_NO_FETCH`, stale-cache fallback, `NEUROVERSE_NO_ORG`, self-reference detection, tier ordering, warning propagation
- [x] Full suite: 565/565 passing
- [x] `tsc --noEmit` clean
- [ ] Manual smoke: create `NeuroverseOS/worlds` on GitHub with a test worldmodel, run `radiant emergent` in another NeuroverseOS repo with no config, confirm auto-load
- [ ] Manual smoke: same with a private `<org>/worlds` — confirm it works with git credentials

## Rollout

**After this merges:**
1. Publish new `@neuroverseos/governance` version to npm
2. Create `NeuroverseOS/worlds` on GitHub (public or private — both work)
3. Drop `neuroverseos-sovereign-conduit.worldmodel.md` into it
4. Every NeuroverseOS repo auto-loads it on next radiant run — no per-repo edits needed

https://claude.ai/code/session_017BjawP2nhLKskyhTu1qsmV