### PR TITLE
chore(release): bump to 0.9.0 past the 0.8.1 on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neuroverseos/governance",
-  "version": "0.6.0",
+  "version": "0.9.0",
   "description": "Deterministic governance engine for AI agents — enforce worlds (permanent rules) and plans (mission constraints) with full audit trace",
   "license": "Apache-2.0",
   "type": "module",
@@ -114,6 +114,7 @@
     "dist/browser.global.js",
     "policies",
     "examples/social-media-sim",
+    "examples/radiant-weekly-workflow.yml",
     "simulate.html",
     "LICENSE.md",
     "README.md",


### PR DESCRIPTION
Two reasons to skip ahead of `npm version patch`'s default 0.6.1:
  1. npm already has 0.8.1 published, so 0.6.x would refuse to publish.
  2. This release carries a real feature — scope-owner discovery means `radiant emergent <org>/` works from any directory. Minor bump fits.

Also adds examples/radiant-weekly-workflow.yml to the published files list so it ships in node_modules, not just on GitHub.