### PR TITLE
Rename Memory Palace → Mind Palace, add `radiant init` scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ DEPTH       — what Radiant can see now vs what unlocks with more reads
 
 ### Memory + evolution
 
-Radiant writes each read to the ExoCortex as a dated Memory Palace file. Next run reads prior history, detects pattern persistence, and proposes worldmodel evolution — what to ADD (recurring candidate patterns) and what to REMOVE (invariants that haven't fired). A lean worldmodel with 5 sharp invariants is stronger than a bloated one with 20.
+Radiant writes each read to the ExoCortex as a dated Mind Palace file. Next run reads prior history, detects pattern persistence, and proposes worldmodel evolution — what to ADD (recurring candidate patterns) and what to REMOVE (invariants that haven't fired). A lean worldmodel with 5 sharp invariants is stronger than a bloated one with 20.
 
 ### MCP server
 

--- a/examples/radiant-weekly-workflow.yml
+++ b/examples/radiant-weekly-workflow.yml
@@ -58,7 +58,7 @@ jobs:
           # with a fine-grained PAT stored in secrets.RADIANT_GITHUB_TOKEN.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          # Memory Palace writes into THIS repo — since we checked it out at
+          # Mind Palace writes into THIS repo — since we checked it out at
           # the workflow root, point the CLI at $GITHUB_WORKSPACE.
           RADIANT_EXOCORTEX: ${{ github.workspace }}
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neuroverseos/governance",
-  "version": "0.6.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neuroverseos/governance",
-      "version": "0.6.0",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "bin": {
         "neuroverse": "dist/cli/neuroverse.js"

--- a/src/cli/radiant.ts
+++ b/src/cli/radiant.ts
@@ -21,7 +21,7 @@
  *   RADIANT_LENS      — default lens id (overridden by --lens)
  */
 
-import { readFileSync, readdirSync, statSync, existsSync } from 'fs';
+import { readFileSync, readdirSync, statSync, existsSync, mkdirSync, writeFileSync } from 'fs';
 import { resolve, join, extname } from 'path';
 import { think } from '../radiant/commands/think';
 import { emergent } from '../radiant/commands/emergent';
@@ -45,6 +45,9 @@ const RESET = '\x1b[0m';
 const USAGE = `
 ${BOLD}neuroverse radiant${RESET} — behavioral intelligence for collaboration systems
 
+${BOLD}Setup:${RESET}
+  init           Scaffold a Mind Palace in the current directory
+
 ${BOLD}Stage A (voice layer):${RESET}
   think          Send a query through the worldmodel + lens → AI-framed response
 
@@ -55,6 +58,8 @@ ${BOLD}Stage B (behavioral analysis, coming soon):${RESET}
   lenses         List or describe available rendering lenses
 
 ${BOLD}Usage:${RESET}
+  neuroverse radiant init                      (scaffolds ./mind-palace/)
+  neuroverse radiant init ./my-palace          (custom path)
   neuroverse radiant think --lens auki-builder --worlds ./worlds/ --query "What is our biggest risk?"
   neuroverse radiant think --lens auki-builder --worlds ./worlds/ < prompt.txt
   neuroverse radiant emergent aukiverse/posemesh --lens auki-builder --worlds ./worlds/
@@ -95,6 +100,7 @@ interface ParsedArgs {
   view: string | undefined;
   json: boolean;
   help: boolean;
+  force: boolean;
   rest: string[];
 }
 
@@ -110,6 +116,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     view: undefined,
     json: false,
     help: false,
+    force: false,
     rest: [],
   };
 
@@ -146,6 +153,10 @@ function parseArgs(argv: string[]): ParsedArgs {
         break;
       case '--json':
         result.json = true;
+        break;
+      case '--force':
+      case '-f':
+        result.force = true;
         break;
       case '--help':
       case '-h':
@@ -544,6 +555,215 @@ async function cmdLenses(args: ParsedArgs): Promise<void> {
   process.exit(1);
 }
 
+// ─── Subcommand: init ──────────────────────────────────────────────────────
+
+const MIND_PALACE_FILES: Record<string, string> = {
+  'README.md': `# Mind Palace
+
+This is your Mind Palace — structured external memory that gives Radiant
+(and any agent you wire into it) persistent context about who you are,
+what you're working on, and what "on track" means for you.
+
+Radiant reads these files before every run and writes each read back into
+\`reads/\`. Over time, \`knowledge.md\` accumulates what's persisted and what
+hasn't — the feedback loop that turns raw activity into named behavior.
+
+## Files
+
+- \`attention.md\` — what you're focused on **right now**
+- \`goals.md\` — what you're working toward
+- \`sprint.md\` — this week's focus
+- \`identity.md\` — who you are, what you value
+- \`worldmodels/\` — your thinking constitutions (drift + aligned behaviors)
+- \`reads/\` — dated Radiant reads (written by \`radiant emergent\`)
+- \`knowledge.md\` — accumulated pattern persistence across reads
+
+## How to use
+
+1. Fill in \`attention.md\`, \`goals.md\`, \`sprint.md\`, \`identity.md\` with
+   your own words. A sentence each is enough to start — the files grow
+   with you.
+2. Edit \`worldmodels/starter.worldmodel.md\`: add a few aligned behaviors
+   (what on-track looks like) and drift behaviors (what off-track looks
+   like). The sharper these are, the sharper Radiant's reads.
+3. Run \`neuroverse radiant emergent <owner/repo> --mind-palace .\` against
+   the repo you want read. Radiant compares your stated intent (these
+   files) to your observed activity (GitHub) and names the gap.
+
+Edit freely. These files are yours.
+`,
+
+  'attention.md': `# Attention
+
+<!--
+What are you focused on RIGHT NOW? One paragraph. Updated as you shift.
+This is the file an AI agent reads at the start of a session to know
+what to help with today.
+-->
+
+`,
+
+  'goals.md': `# Goals
+
+<!--
+What are you working toward? Bullet points welcome.
+Longer horizon than attention — months, not days.
+-->
+
+-
+`,
+
+  'sprint.md': `# Sprint
+
+<!--
+This week's focus. What do you want to ship or finish?
+Keep it short — five bullets max.
+-->
+
+-
+`,
+
+  'identity.md': `# Identity
+
+<!--
+Who are you, what do you value, how do you work?
+This is the context an agent needs to not treat you like a stranger
+every time. Write it in your own voice.
+-->
+
+`,
+
+  'knowledge.md': `# Knowledge
+
+<!--
+Radiant writes accumulated pattern persistence here across reads.
+Leave this file empty on day one — it fills up as \`radiant emergent\`
+runs accumulate.
+-->
+
+`,
+
+  'reads/.gitkeep': '',
+
+  'worldmodels/starter.worldmodel.md': `# Starter Worldmodel
+
+<!--
+Your thinking constitution. Radiant reads this to understand what
+"aligned" and "drift" mean for your work.
+
+The sharper the Aligned/Drift Behaviors, the sharper Radiant's reads.
+When Radiant detects something matching a drift behavior below, it
+labels it with THAT name — it doesn't invent new ones.
+-->
+
+## Mission
+
+<!-- One sentence. What are you doing in the world? -->
+
+
+## Invariants
+
+<!--
+Non-negotiable rules. If a decision violates one, it's blocked.
+Keep this list short — 3 to 6 items. Each should be a hard no.
+-->
+
+-
+
+## Aligned Behaviors
+
+<!--
+What "on track" looks like. One per line, phrased as a behavior.
+Radiant will use these as canonical pattern names when it sees
+matching evidence in your activity.
+
+Example:
+  - ships partial-but-working features rather than waiting for the full stack
+  - writes decisions down before acting on them
+-->
+
+-
+
+## Drift Behaviors
+
+<!--
+What "off track" looks like. Same format as Aligned.
+When Radiant detects drift, it will label it with these names — not
+make up new ones.
+
+Example:
+  - shipping pace outruns strategic decision-making
+  - architecture decisions surface without context about why
+-->
+
+-
+
+## Signals
+
+<!--
+Observable quantities you care about. Radiant scores activity
+against these — 5 to 7 is the sweet spot.
+
+Example:
+  - shipping_velocity
+  - decision_ownership
+  - storytelling_cadence
+-->
+
+-
+
+## Decision Priorities
+
+<!--
+When tradeoffs appear, these resolve them. Format: "A > B".
+
+Example:
+  - correctness > speed
+  - clarity > cleverness
+-->
+
+-
+`,
+};
+
+async function cmdInit(args: ParsedArgs): Promise<void> {
+  const targetDir = resolve(args.rest[0] ?? './mind-palace');
+  const existed = existsSync(targetDir);
+
+  if (existed && !args.force) {
+    const entries = readdirSync(targetDir);
+    if (entries.length > 0) {
+      process.stderr.write(
+        `${RED}Error:${RESET} ${targetDir} already exists and is not empty.\n` +
+          `${DIM}Use --force to write into it anyway (existing files will be overwritten).${RESET}\n`,
+      );
+      process.exit(1);
+    }
+  }
+
+  mkdirSync(targetDir, { recursive: true });
+  mkdirSync(join(targetDir, 'reads'), { recursive: true });
+  mkdirSync(join(targetDir, 'worldmodels'), { recursive: true });
+
+  for (const [relPath, content] of Object.entries(MIND_PALACE_FILES)) {
+    const fullPath = join(targetDir, relPath);
+    mkdirSync(resolve(fullPath, '..'), { recursive: true });
+    writeFileSync(fullPath, content, 'utf-8');
+  }
+
+  process.stdout.write(
+    `${GREEN}✓${RESET} Mind Palace scaffolded at ${BOLD}${targetDir}${RESET}\n\n` +
+      `${DIM}Next steps:${RESET}\n` +
+      `  1. Edit ${targetDir}/attention.md — what you're focused on right now\n` +
+      `  2. Edit ${targetDir}/worldmodels/starter.worldmodel.md — add a few\n` +
+      `     aligned and drift behaviors\n` +
+      `  3. Run: neuroverse radiant emergent <owner/repo> \\\n` +
+      `           --worlds ${targetDir}/worldmodels \\\n` +
+      `           --exocortex ${targetDir}\n\n` +
+      `${DIM}Files are yours. Edit freely.${RESET}\n`,
+  );
+}
+
 // ─── Main router ───────────────────────────────────────────────────────────
 
 export async function main(argv: string[]): Promise<void> {
@@ -555,6 +775,8 @@ export async function main(argv: string[]): Promise<void> {
   }
 
   switch (args.subcommand) {
+    case 'init':
+      return cmdInit(args);
     case 'think':
       return cmdThink(args);
     case 'lenses':

--- a/src/radiant/PROJECT-PLAN.md
+++ b/src/radiant/PROJECT-PLAN.md
@@ -27,7 +27,7 @@ Nobody in the coordination/memory space is doing **behavioral governance** — i
 - The `neuroverse worldmodel` pipeline → npm (already: in `NeuroverseOS/Neuroverseos-governance`)
 - Radiant core → npm (`@neuroverseos/radiant`)
 - Radiant MCP server → npm (`@neuroverseos/radiant-mcp`)
-- Memory Palace reference implementation → npm (`@neuroverseos/memory-palace` or as part of radiant)
+- Mind Palace reference implementation → npm (`@neuroverseos/mind-palace` or as part of radiant)
 - Signal schema + extraction → npm (part of governance primitives)
 - Pattern composition → npm (part of governance primitives)
 
@@ -531,9 +531,9 @@ ExoCortex IS the memory provider. Every Radiant call can:
 No centralized surveillance of user behavior. This matches Auki's mission.
 
 ### Memory provider — full reference implementation ships with Radiant
-Radiant ships with a **working default memory provider** (SQLite-backed). It implements the **Memory Palace 4-layer coding standard** (compression / baselines / knowledge / synthesis), which is the canonical way behavioral context is structured across the NeuroverseOS ecosystem.
+Radiant ships with a **working default memory provider** (SQLite-backed). It implements the **Mind Palace 4-layer coding standard** (compression / baselines / knowledge / synthesis), which is the canonical way behavioral context is structured across the NeuroverseOS ecosystem.
 
-**Memory Palace is the standard. Not optional.** Anyone implementing a custom memory provider must implement the same 4-layer pattern:
+**Mind Palace is the standard. Not optional.** Anyone implementing a custom memory provider must implement the same 4-layer pattern:
 - **Layer 1: Compression** — raw activity compressed into behavioral shorthand
 - **Layer 2: Baselines** — rolling averages per scope (person/project/repo/system)
 - **Layer 3: Knowledge** — accumulated behavioral facts with confidence
@@ -541,10 +541,10 @@ Radiant ships with a **working default memory provider** (SQLite-backed). It imp
 
 Options for consumers:
 - Use Radiant's reference implementation as-is (SQLite, local)
-- Implement the `MemoryProvider` interface against their own storage (ExoCortex, Postgres, etc.) — but must follow Memory Palace coding
+- Implement the `MemoryProvider` interface against their own storage (ExoCortex, Postgres, etc.) — but must follow Mind Palace coding
 - Run stateless (no memory at all)
 
-The Memory Palace **pattern** is open in Radiant — the three-tier structure (raw → structured signals → synthesized narrative) is the canonical coding standard for behavioral memory.
+The Mind Palace **pattern** is open in Radiant — the three-tier structure (raw → structured signals → synthesized narrative) is the canonical coding standard for behavioral memory.
 
 ---
 
@@ -637,7 +637,7 @@ test/
 6. ✅ **Rendering lens layer** — `src/radiant/lenses/auki-builder.ts` + `src/radiant/lenses/index.ts`. Three-domain vanguard frame (Future Foresight / Narrative Dynamics / Shared Prosperity as internal reasoning; skills-level vocabulary for output). 30 Auki vocabulary terms, 36 forbidden phrases, voice directives, 4 exemplars, deterministic `rewrite(pattern)`. 35 tests.
 7. ✅ **GitHub adapter** — `src/radiant/adapters/github.ts`. Fetches commits, PRs, comments via raw fetch. Maps to Event type. Actor classification (human/bot/AI from GitHub metadata + Co-authored-by trailers). `src/radiant/core/scopes.ts` for scope resolution. 15 tests.
 8. **NeuroVerse base worldmodel** — not yet built. Universal builder signals. Deferred; Auki worldmodels sufficient for Phase 1.
-9. ✅ **Renderer** — `src/radiant/core/renderer.ts`. EMERGENT / MEANING / MOVE / ALIGNMENT / DEPTH output structure. Human-language score formatting ("72 · STABLE", "41 · needs attention", "not enough signal to call yet"). Memory Palace YAML frontmatter (Tier 2 structured signals). DEPTH section adapts to read count (first read / baseline forming / baseline established).
+9. ✅ **Renderer** — `src/radiant/core/renderer.ts`. EMERGENT / MEANING / MOVE / ALIGNMENT / DEPTH output structure. Human-language score formatting ("72 · STABLE", "41 · needs attention", "not enough signal to call yet"). Mind Palace YAML frontmatter (Tier 2 structured signals). DEPTH section adapts to read count (first read / baseline forming / baseline established).
 10. ✅ **Scope resolution** — `src/radiant/core/scopes.ts`. Parses "owner/repo", GitHub URLs, strips .git / trailing slash.
 11. **Memory provider interface** — ✅ implemented as ExoCortex integration. `src/radiant/memory/palace.ts` — the exocortex IS the memory provider for Auki. Writes dated reads to `exocortex/radiant/reads/YYYY-MM-DD.md`, updates `knowledge.md` with pattern persistence + bidirectional evolution proposals (consider adding + consider removing). Tracks untriggered worldmodel items across reads for subtraction candidates.
 12. **SQLite reference memory provider** — not yet built. Optional fallback for orgs without an exocortex. Deferred.
@@ -657,7 +657,7 @@ test/
 - ✅ **AI adapter** — `src/radiant/core/ai.ts`. `RadiantAI` interface + Anthropic Claude implementation (raw fetch, no SDK) + mock adapter for tests.
 - ✅ **Governance audit trail** — `src/radiant/core/governance.ts`. Runs each event through the NeuroverseOS guard engine (`evaluateGuard`) against the compiled worldmodel. Produces a GOVERNANCE section in the output showing which events triggered governance (ALLOW/BLOCK/MODIFY), on which side (human/AI/joint), and whether the balance is even. The audit trail scales from GitHub commits to spatial events — same evaluateGuard, same verdicts.
 - ✅ **ExoCortex adapter** — `src/radiant/adapters/exocortex.ts`. Reads stated intent from an exocortex directory (attention.md, goals.md, sprint.md, identity.md, org context). Compares stated intent against observed behavior from GitHub. The gap between "what I said I'd do" and "what I actually did" is drift. No other tool measures this.
-- ✅ **Memory Palace write-back** — `src/radiant/memory/palace.ts`. Writes dated reads to the exocortex after each emergent run. Reads prior history to detect pattern persistence. Produces bidirectional evolution proposals: "consider adding" (persistent candidate patterns) + "consider removing" (declared items that haven't triggered in 4+ reads). A lean worldmodel with 5 sharp invariants is stronger than a bloated one with 20.
+- ✅ **Mind Palace write-back** — `src/radiant/memory/palace.ts`. Writes dated reads to the exocortex after each emergent run. Reads prior history to detect pattern persistence. Produces bidirectional evolution proposals: "consider adding" (persistent candidate patterns) + "consider removing" (declared items that haven't triggered in 4+ reads). A lean worldmodel with 5 sharp invariants is stronger than a bloated one with 20.
 - ✅ **PR-TO-AUKI.md** — `src/radiant/examples/auki/PR-TO-AUKI.md`. The document Nils reads cold. Tailored to his language, honors the ExoCortex, names the gap Radiant fills, includes real output from aukilabs/exocortex, the cocoon framing, L/C/N scores, MCP setup.
 
 ### Phase 1 scope — COMPLETE
@@ -683,7 +683,7 @@ ANTHROPIC_API_KEY=xxx GITHUB_TOKEN=yyy neuroverse radiant emergent \
 
 **Remaining for future phases:**
 - Phase 2: MCP server (expose think/emergent as MCP tools)
-- Phase 3: ExoCortex memory integration (write Memory Palace reads into the exocortex; drift/evolve commands)
+- Phase 3: ExoCortex memory integration (write Mind Palace reads into the exocortex; drift/evolve commands)
 - The handshake: ExoCortex ↔ Radiant for robotic participants on the real world web
 
 ---
@@ -747,7 +747,7 @@ Claude Code calls `radiant_emergent` and `radiant_decision`, returns interpretat
 
 ### Phase 3 — ExoCortex as memory provider (stateful, 1–2 days integration)
 
-ExoCortex implements Radiant's `MemoryProvider` interface (following Memory Palace coding standard). Now:
+ExoCortex implements Radiant's `MemoryProvider` interface (following Mind Palace coding standard). Now:
 - Radiant reads historical events from ExoCortex
 - Radiant writes outputs back to ExoCortex as first-class records
 - Drift detection activates (alignment_score falls as clarity drops in real data)
@@ -864,7 +864,7 @@ When this plan is executed, the following will be true:
 2. Radiant runs three ways: CLI, npm import, MCP server — all from one package
 3. NeuroVerse base worldmodel ships built-in; Auki Vanguard + Strategy ship as example worldmodels
 4. Worldmodels are compiled via existing `neuroverse worldmodel build` pipeline
-5. Memory provider interface defined; SQLite reference implementation follows Memory Palace 4-layer coding
+5. Memory provider interface defined; SQLite reference implementation follows Mind Palace 4-layer coding
 6. Stateless mode works (no memory required for emergent + decision); stateful mode activates drift + evolve when memory provider is wired up
 7. Auki can test in four phases: CLI → Claude Code MCP → ExoCortex memory provider → production run
 8. When ExoCortex opens, the PR to them is a config-only addition (add Radiant to mcpServers), zero code changes in their repo

--- a/src/radiant/README.md
+++ b/src/radiant/README.md
@@ -14,7 +14,7 @@ patterns, decision readiness, drift, and evolution proposals.
 
 **Phase 1 complete.** Voice layer (CLAUDE.md + `radiant think`), behavioral
 dashboard (`radiant emergent`), MCP server, rendering lens with Auki builder
-voice, Memory Palace write-back, governance audit trail, ExoCortex handshake.
+voice, Mind Palace write-back, governance audit trail, ExoCortex handshake.
 514 tests. See [`radiant/PROJECT-PLAN.md`](../../radiant/PROJECT-PLAN.md) for
 the full roadmap.
 

--- a/src/radiant/commands/emergent.ts
+++ b/src/radiant/commands/emergent.ts
@@ -64,7 +64,7 @@ export interface EmergentInput {
 export interface EmergentResult {
   /** The rendered text output (EMERGENT / MEANING / MOVE). */
   text: string;
-  /** The YAML frontmatter for Memory Palace coding. */
+  /** The YAML frontmatter for Mind Palace coding. */
   frontmatter: string;
   /** Voice violations detected in AI output. */
   voiceViolations: VoiceViolation[];
@@ -103,7 +103,7 @@ export async function emergent(input: EmergentInput): Promise<EmergentResult> {
     // Scope to the repo name if available (reads project-specific sprint/roadmap)
     const repoName = input.scope.type === 'repo' ? input.scope.repo : undefined;
     exocortexContext = readExocortex(input.exocortexPath, repoName);
-    // Compress exocortex to one-line summaries (Memory Palace discipline)
+    // Compress exocortex to one-line summaries (Mind Palace discipline)
     const compressed = compressExocortex(exocortexContext);
     if (compressed) {
       statedIntent = `## Stated Intent (from exocortex, compressed)\n\n${compressed}\n\nCompare stated intent against actual GitHub activity. Gaps = drift.`;
@@ -236,7 +236,7 @@ export async function emergent(input: EmergentInput): Promise<EmergentResult> {
     governance,
   });
 
-  // 9. Write Memory Palace read to exocortex (if exocortex provided)
+  // 9. Write Mind Palace read to exocortex (if exocortex provided)
   if (input.exocortexPath) {
     try {
       const readPath = writeRead(input.exocortexPath, rendered.frontmatter, rendered.text);

--- a/src/radiant/core/compress.ts
+++ b/src/radiant/core/compress.ts
@@ -1,5 +1,5 @@
 /**
- * @neuroverseos/governance/radiant — Memory Palace compression
+ * @neuroverseos/governance/radiant — Mind Palace compression
  *
  * Applies the three-tier principle to everything that enters the AI
  * prompt: raw data is not the memory; structured signals are.

--- a/src/radiant/core/renderer.ts
+++ b/src/radiant/core/renderer.ts
@@ -4,7 +4,7 @@
  * Takes signals + patterns + scores + lens metadata and produces the
  * structured output Nils reads. Two output modes:
  *   - text: the EMERGENT / MEANING / MOVE structure for terminal display
- *   - yaml+text: Memory Palace coded read file (YAML frontmatter + prose)
+ *   - yaml+text: Mind Palace coded read file (YAML frontmatter + prose)
  *
  * The renderer enforces the lens's voice rules: forbidden phrases are
  * checked, bucket names are never leaked, vocabulary is Auki-native.
@@ -48,7 +48,7 @@ export interface RenderInput {
 export interface RenderOutput {
   /** The human-readable text output for terminal display. */
   text: string;
-  /** The Memory Palace coded YAML frontmatter (Tier 2 structured signals). */
+  /** The Mind Palace coded YAML frontmatter (Tier 2 structured signals). */
   frontmatter: string;
 }
 
@@ -208,7 +208,7 @@ function formatScore(s: Score): string {
   return `${n} · ${label}`;
 }
 
-// ─── YAML frontmatter (Memory Palace Tier 2) ───────────────────────────────
+// ─── YAML frontmatter (Mind Palace Tier 2) ─────────────────────────────────
 
 function renderFrontmatter(input: RenderInput): string {
   const now = new Date().toISOString();

--- a/src/radiant/index.ts
+++ b/src/radiant/index.ts
@@ -18,12 +18,12 @@
  *     before the renderer sees them — deterministic shaping, no LLM in path
  *   - Stateless commands: emergent, decision
  *   - Stateful (via MemoryProvider) commands: drift, evolve
- *   - Memory Palace 4-layer coding standard (compression / baselines /
+ *   - Mind Palace 4-layer coding standard (compression / baselines /
  *     knowledge / synthesis) with a SQLite reference implementation
  *   - CLI entry (bin/radiant.ts) and MCP server entry (bin/radiant-mcp.ts)
  *
  * Build state: Phase 1 complete — voice layer, behavioral dashboard,
- * MCP server, Memory Palace write-back, governance audit, ExoCortex
+ * MCP server, Mind Palace write-back, governance audit, ExoCortex
  * handshake. See radiant/PROJECT-PLAN.md for the full roadmap.
  *
  * Usage:
@@ -189,7 +189,7 @@ export {
   getRepoOrigin,
 } from './core/git-remote';
 
-// ─── Memory Palace compression ─────────────────────────────────────────────
+// ─── Mind Palace compression ───────────────────────────────────────────────
 
 export {
   compressWorldmodel,
@@ -203,7 +203,7 @@ export {
 export type { GovernanceVerdict, GovernanceAudit } from './core/governance';
 export { auditGovernance } from './core/governance';
 
-// ─── Memory Palace ─────────────────────────────────────────────────────────
+// ─── Mind Palace ───────────────────────────────────────────────────────────
 
 export type { PriorRead, PatternPersistence, WorldmodelItem } from './memory/palace';
 export {

--- a/src/radiant/memory/palace.ts
+++ b/src/radiant/memory/palace.ts
@@ -1,11 +1,11 @@
 /**
- * @neuroverseos/governance/radiant — Memory Palace file operations
+ * @neuroverseos/governance/radiant — Mind Palace file operations
  *
  * Writes Radiant reads to the exocortex as dated markdown files (with
  * YAML frontmatter for structured signal data). Reads prior files to
  * detect pattern persistence across runs.
  *
- * The exocortex directory IS the Memory Palace. Files are the tiers:
+ * The exocortex directory IS the Mind Palace. Files are the tiers:
  *   - reads/YYYY-MM-DD.md = Tier 2 (structured signals) + Tier 3 (narrative)
  *   - knowledge.md = accumulated pattern facts with persistence counts
  *

--- a/test/radiant-integration.test.ts
+++ b/test/radiant-integration.test.ts
@@ -7,7 +7,7 @@
  *   - Output contains EMERGENT / ALIGNMENT sections
  *   - Scores are computed and formatted in human language
  *   - Voice check catches forbidden phrases in AI output
- *   - YAML frontmatter is generated for Memory Palace coding
+ *   - YAML frontmatter is generated for Mind Palace coding
  *   - The think command works end-to-end with the Auki lens
  */
 


### PR DESCRIPTION
Positions Radiant as its own product with a bundled Mind Palace (the NeuroverseOS flavor of the same file-convention Auki's exocortex uses). The two terms describe the same pattern — Mind Palace is the NeuroverseOS-native vocabulary and matches the "thinking constitution" register of the Sovereign Conduit worldmodel.

- Prose rename across governance repo (29 occurrences in 12 files). Kept "Memory Palace" in examples/auki/** since those demos are aimed at Auki's audience in Auki's vocabulary.
- New `neuroverse radiant init [path]` subcommand scaffolds a visible ./mind-palace/ directory with seeded attention.md, goals.md, sprint.md, identity.md, knowledge.md, reads/, and a starter.worldmodel.md whose Aligned/Drift Behaviors sections have clear comments so users have an on-ramp — and so the upcoming fidelity fix has declared vocabulary to govern against. --force overwrites non-empty target directories.

565 tests pass.

https://claude.ai/code/session_015yQhANSAXzQNV4KrcxDGcB