### PR TITLE
@neuroverseos/governance@0.11.0 — observe mode + auditBehavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-04-18
+
+### Added
+- **Observe mode (`mode: 'observe'` on `evaluateGuard`)** — runs every evaluation layer identically to enforce mode, then coerces any non-ALLOW verdict to ALLOW before returning. The original status is preserved on `GuardVerdict.shadowStatus` and `shadowReason`. Nothing is blocked, paused, or modified; the caller passes the action through and reads the shadow fields to know what WOULD have happened. This is the primitive behind Bevia/Radiant's "Mirror Mode" framing: see where your team crosses what you said you lead by, without imposing enforcement.
+- **`auditBehavior(event, world)` and `auditBehaviors(events, world)`** helpers (`@neuroverseos/governance`) — consume an `AuditableEvent` (loose shape covering commits, PRs, chat messages, etc.), wrap it into a synthetic `GuardEvent`, and evaluate in observe mode. Return `Crossing` records shaped for behavioral audit logs: `eventId`, `timestamp`, `shadowStatus`, `shadowReason`, `ruleId`, `excerpt`, `wouldHaveBlocked`, plus the full verdict.
+- **`neuroverse audit` CLI** — observe-mode counterpart to `neuroverse guard`. Always exits 0. Supports `--multi` to evaluate a JSON array of events and `--crossings-only` to filter down to just the interesting ones. Useful for replaying past activity through a new world to preview its behavior before flipping it to enforce.
+- **Radiant `GovernanceAudit.crossings`** (`@neuroverseos/governance/radiant`) — `auditGovernance` now evaluates in observe mode and emits a `crossings: Crossing[]` array alongside the existing human/cyber/joint buckets. Bevia surfaces these as "moments the team bumped against your worldmodel" in the dashboard and in `radiant_team_read` MCP responses.
+
+### Changed
+- **Internal `evaluateGuard` refactor** — the body of the public `evaluateGuard` was renamed `evaluateGuardCore` and wrapped with a thin public function that applies observe-mode transformation. No behavior change for existing callers; `evaluateGuard(event, world)` without the new `mode` option returns exactly the same verdict as before.
+- **`GovernanceAudit` shape** — added `crossings` field. Non-breaking additive change; existing consumers reading only `totalEvents`, `human`, `cyber`, `joint`, or `summary` are unaffected.
+
 ## [0.10.0] - 2026-04-18
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neuroverseos/governance",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Deterministic governance engine for AI agents — enforce worlds (permanent rules) and plans (mission constraints) with full audit trace",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/cli/audit.ts
+++ b/src/cli/audit.ts
@@ -1,0 +1,136 @@
+/**
+ * CLI Harness: neuroverse audit
+ *
+ * Observe-mode counterpart to `neuroverse guard`. Reads a GuardEvent from
+ * stdin (or --file), evaluates it against a world in OBSERVE MODE, and
+ * emits a verdict that captures what WOULD have happened without
+ * enforcing anything. Always exits 0 (observe mode never blocks).
+ *
+ * Use cases:
+ *   - Preview how a new world would behave before flipping it to enforce
+ *   - Run a replay of past activity through a newly-authored world to see
+ *     what would have crossed
+ *   - Build Radiant-style "crossings" reports for a team without imposing
+ *     any live-run enforcement
+ *
+ * Usage:
+ *   echo '{"intent":"deploy to prod"}' | neuroverse audit --world ./my-world/
+ *   cat events.json | neuroverse audit --world ./my-world/ --multi
+ *
+ * Flags:
+ *   --world <path>   Path to world directory or .nv-world.zip (required)
+ *   --trace          Include full evaluation trace in output
+ *   --level <level>  Override enforcement level (basic|standard|strict)
+ *   --multi          Read a JSON array of GuardEvents and return an
+ *                    array of verdicts (one per event). Default: single.
+ *   --crossings-only When combined with --multi, emit only the events
+ *                    whose shadowStatus != ALLOW. Good for piping to
+ *                    reports / dashboards.
+ */
+
+import { evaluateGuard } from '../engine/guard-engine';
+import { loadWorld } from '../loader/world-loader';
+import { resolveWorldPath } from '../loader/world-resolver';
+import type { GuardEvent, GuardVerdict } from '../contracts/guard-contract';
+import { readStdin } from './cli-utils';
+
+interface CliArgs {
+  worldPath: string;
+  trace: boolean;
+  level?: 'basic' | 'standard' | 'strict';
+  multi: boolean;
+  crossingsOnly: boolean;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  let worldPath = '';
+  let trace = false;
+  let level: 'basic' | 'standard' | 'strict' | undefined;
+  let multi = false;
+  let crossingsOnly = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--world') worldPath = argv[++i] ?? '';
+    else if (a === '--trace') trace = true;
+    else if (a === '--level') {
+      const v = argv[++i];
+      if (v === 'basic' || v === 'standard' || v === 'strict') level = v;
+    } else if (a === '--multi') multi = true;
+    else if (a === '--crossings-only') crossingsOnly = true;
+  }
+
+  return { worldPath, trace, level, multi, crossingsOnly };
+}
+
+function usage(): void {
+  process.stderr.write(
+    'Usage: neuroverse audit --world <path> [--trace] [--level basic|standard|strict] [--multi] [--crossings-only]\n' +
+    '\n' +
+    'Reads GuardEvent JSON from stdin. With --multi, reads a JSON array.\n' +
+    'Evaluates in observe mode — no enforcement. Verdicts carry\n' +
+    'shadowStatus/shadowReason for any event that would have crossed.\n',
+  );
+}
+
+export async function main(argv: string[]): Promise<number> {
+  const args = parseArgs(argv);
+  if (!args.worldPath) {
+    usage();
+    return 1;
+  }
+
+  let world;
+  try {
+    const resolved = resolveWorldPath(args.worldPath);
+    world = await loadWorld(resolved);
+  } catch (err) {
+    process.stderr.write(`Failed to load world: ${err instanceof Error ? err.message : err}\n`);
+    return 1;
+  }
+
+  let raw = '';
+  try {
+    raw = await readStdin();
+  } catch (err) {
+    process.stderr.write(`Failed to read stdin: ${err instanceof Error ? err.message : err}\n`);
+    return 1;
+  }
+
+  if (!raw.trim()) {
+    process.stderr.write('No input on stdin. Pipe a GuardEvent or a JSON array with --multi.\n');
+    return 1;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    process.stderr.write(`Invalid JSON on stdin: ${err instanceof Error ? err.message : err}\n`);
+    return 1;
+  }
+
+  const options = { trace: args.trace, level: args.level, mode: 'observe' as const };
+
+  if (args.multi) {
+    if (!Array.isArray(parsed)) {
+      process.stderr.write('--multi expects a JSON array on stdin.\n');
+      return 1;
+    }
+    const verdicts: GuardVerdict[] = (parsed as GuardEvent[]).map((e) =>
+      evaluateGuard(e, world, options),
+    );
+    const out = args.crossingsOnly
+      ? verdicts.filter((v) => v.shadowStatus && v.shadowStatus !== 'ALLOW')
+      : verdicts;
+    process.stdout.write(JSON.stringify(out, null, 2) + '\n');
+    return 0;
+  }
+
+  const verdict = evaluateGuard(parsed as GuardEvent, world, options);
+  process.stdout.write(JSON.stringify(verdict, null, 2) + '\n');
+  // Observe mode exits 0 whether or not there was a crossing. Callers
+  // who want a non-zero exit on a crossing should inspect shadowStatus
+  // from the JSON output themselves.
+  return 0;
+}

--- a/src/cli/neuroverse.ts
+++ b/src/cli/neuroverse.ts
@@ -114,6 +114,10 @@ async function main(): Promise<void> {
       const { main: guardMain } = await import('./guard');
       return guardMain(subArgs);
     }
+    case 'audit': {
+      const { main: auditMain } = await import('./audit');
+      return auditMain(subArgs);
+    }
     case 'test': {
       const { main: testMain } = await import('./test');
       return testMain(subArgs);

--- a/src/contracts/guard-contract.ts
+++ b/src/contracts/guard-contract.ts
@@ -240,6 +240,22 @@ export interface GuardVerdict {
   /** ID of the rule/guard that produced this verdict */
   ruleId?: string;
 
+  /**
+   * Shadow verdict — populated when the engine ran in `mode: 'observe'`.
+   * If the real enforcement decision would have been BLOCK/PAUSE/MODIFY/
+   * PENALIZE, that original status is captured here while `status` is
+   * coerced to ALLOW so the caller passes the action through.
+   *
+   * Use this for observe/shadow/mirror-mode governance: the engine
+   * records every crossing of a rule without stopping anything. Lets
+   * teams adopt governance without the political cost of enforcement,
+   * and lets tools like Radiant surface which invariants got bumped.
+   */
+  shadowStatus?: GuardStatus;
+
+  /** Reason the shadow verdict fired (empty when shadowStatus is absent) */
+  shadowReason?: string;
+
   /** Advisory warning (for ALLOW with warn-mode guards) */
   warning?: string;
 
@@ -409,6 +425,25 @@ export interface GuardEngineOptions {
 
   /** Enforcement level override. If not set, uses world default or 'standard'. */
   level?: 'basic' | 'standard' | 'strict';
+
+  /**
+   * Enforcement mode.
+   *
+   * - `'enforce'` (default) — the engine returns its real verdict. BLOCK
+   *   blocks, PAUSE pauses, PENALIZE penalizes, MODIFY modifies.
+   *
+   * - `'observe'` — the engine evaluates every rule exactly the same way,
+   *   but coerces non-ALLOW verdicts to ALLOW before returning. The
+   *   original status is preserved on `shadowStatus` so the caller can
+   *   record the crossing without blocking the action. Used by Radiant
+   *   + Bevia to show leaders where their worldmodel is being touched
+   *   without imposing enforcement, and by teams who want to roll out
+   *   governance gradually rule-by-rule.
+   *
+   * Observe mode does NOT alter the evaluation — all layers still run.
+   * It only changes how the final verdict is packaged for the caller.
+   */
+  mode?: 'enforce' | 'observe';
 
   /**
    * Session allowlist — set of pre-approved event keys.

--- a/src/engine/audit-behavior.ts
+++ b/src/engine/audit-behavior.ts
@@ -1,0 +1,148 @@
+/**
+ * @neuroverseos/governance — auditBehavior
+ *
+ * Takes an observed event (from the Radiant pipeline: a commit, a PR, a
+ * Slack message, a Notion edit) and evaluates it against a worldmodel in
+ * observe mode — without any enforcement side effects. Returns the shadow
+ * verdict so callers can record crossings of declared invariants.
+ *
+ * This is the primitive that lets Bevia / Radiant / Mirror-Mode tooling
+ * show leaders where their worldmodel is being bumped against, without
+ * imposing any stop/pause/modify semantics on the team's work.
+ *
+ * Relationship to evaluateGuard:
+ *
+ *   evaluateGuard({ intent, ... }, world, { mode: 'enforce' })
+ *     → what an AI agent receives when governance says "BLOCK this action"
+ *
+ *   evaluateGuard({ intent, ... }, world, { mode: 'observe' })
+ *     → what tooling like Bevia receives when governance says "this would
+ *        have been blocked if enforced, but pass through and record"
+ *
+ *   auditBehavior(event, world)
+ *     → convenience on top of the observe path that (a) maps a
+ *        behavioral event into a synthetic GuardEvent, (b) calls
+ *        evaluateGuard in observe mode, and (c) returns a Crossing
+ *        record shaped for behavioral logs.
+ *
+ * The mapping from behavioral events to GuardEvents is intentionally
+ * conservative: we use the event's `kind` as the tool, its `content` as
+ * the intent, and pass through timestamp + actor as metadata. Callers
+ * that want richer mappings (classifying event semantics into tool
+ * namespaces, etc.) can construct a GuardEvent directly and call
+ * evaluateGuard themselves.
+ */
+
+import { evaluateGuard } from './guard-engine';
+import type { GuardEvent, GuardStatus, GuardVerdict } from '../contracts/guard-contract';
+import type { WorldDefinition } from '../types';
+
+/**
+ * Minimal shape an observed event needs to be auditable. Matches the
+ * Radiant `Event` type's relevant fields but doesn't require importing
+ * the full radiant domain module — keeps auditBehavior consumable by any
+ * adapter that emits events.
+ */
+export interface AuditableEvent {
+  /** Source-system-unique id (e.g. "github-push-abc123", "slack-msg-789"). */
+  id: string;
+  /** ISO 8601. */
+  timestamp: string;
+  /** Free-form kind tag from the adapter — 'commit', 'pr_opened', 'chat_message', etc. */
+  kind?: string;
+  /** Textual content of the event — commit message, PR body, chat text, etc. */
+  content?: string;
+  /** Actor id that produced the event. */
+  actorId?: string;
+  /** Actor kind — 'human' | 'ai' | 'bot' | 'unknown'. */
+  actorKind?: string;
+  /** Optional repo / channel / page reference, passed through as GuardEvent.scope. */
+  scope?: string;
+}
+
+/**
+ * A single crossing record — an observed event that would have triggered
+ * a non-ALLOW verdict if the world were running in enforce mode.
+ *
+ * When `wouldHaveBlocked` is `false`, the event passed all layers cleanly
+ * and no crossing occurred. Crossing records are most useful when
+ * `wouldHaveBlocked` is `true` — that's a moment the leader said they
+ * cared about, and here's evidence their team bumped into it.
+ */
+export interface Crossing {
+  eventId: string;
+  timestamp: string;
+  kind?: string;
+  actorId?: string;
+  /** The status the engine would have returned in enforce mode. */
+  shadowStatus: GuardStatus;
+  /** Human-readable reason the shadow verdict fired. */
+  shadowReason?: string;
+  /** Rule or guard id that produced the shadow verdict. */
+  ruleId?: string;
+  /** Shortened quote of the event content — useful for a crossings panel. */
+  excerpt?: string;
+  /** True when the engine would have blocked/paused/etc. in enforce mode. */
+  wouldHaveBlocked: boolean;
+  /** Full verdict in case callers want the complete object. */
+  verdict: GuardVerdict;
+}
+
+/**
+ * Evaluate a single behavioral event against a world in observe mode.
+ */
+export function auditBehavior(
+  event: AuditableEvent,
+  world: WorldDefinition,
+): Crossing {
+  const guardEvent = toGuardEvent(event);
+  const verdict = evaluateGuard(guardEvent, world, { mode: 'observe' });
+  const wouldHaveBlocked = verdict.shadowStatus !== undefined && verdict.shadowStatus !== 'ALLOW';
+
+  return {
+    eventId: event.id,
+    timestamp: event.timestamp,
+    kind: event.kind,
+    actorId: event.actorId,
+    shadowStatus: verdict.shadowStatus ?? 'ALLOW',
+    shadowReason: verdict.shadowReason,
+    ruleId: verdict.ruleId,
+    excerpt: event.content ? excerptContent(event.content) : undefined,
+    wouldHaveBlocked,
+    verdict,
+  };
+}
+
+/**
+ * Convenience: audit a whole stream of events. Returns one Crossing per
+ * event; the caller can filter `wouldHaveBlocked` to get only the
+ * interesting ones. Deterministic — same events + same world = same
+ * crossings, every time.
+ */
+export function auditBehaviors(
+  events: AuditableEvent[],
+  world: WorldDefinition,
+): Crossing[] {
+  return events.map((e) => auditBehavior(e, world));
+}
+
+// ─── Mapping helpers ──────────────────────────────────────────────────────
+
+function toGuardEvent(event: AuditableEvent): GuardEvent {
+  return {
+    intent: event.content ?? event.kind ?? 'unspecified',
+    tool: event.kind,
+    scope: event.scope,
+    payload: {
+      actorId: event.actorId,
+      actorKind: event.actorKind,
+      timestamp: event.timestamp,
+      sourceEventId: event.id,
+    },
+  };
+}
+
+function excerptContent(content: string, max = 280): string {
+  if (content.length <= max) return content;
+  return content.slice(0, max - 1).trimEnd() + '…';
+}

--- a/src/engine/guard-engine.ts
+++ b/src/engine/guard-engine.ts
@@ -172,11 +172,57 @@ function isExternalScope(scope: string): boolean {
  *
  * This is the entire guard engine. One function. Deterministic.
  * No class instantiation, no state, no side effects.
+ *
+ * Two modes, same evaluation logic:
+ *
+ *   mode: 'enforce' (default)
+ *     Returns the real verdict — BLOCK blocks, PAUSE pauses, MODIFY
+ *     modifies, PENALIZE penalizes.
+ *
+ *   mode: 'observe'
+ *     Runs every layer identically, then coerces any non-ALLOW verdict
+ *     to ALLOW before returning — preserving the original status on
+ *     `shadowStatus`. The caller passes the action through; Radiant /
+ *     Bevia / audit logs read `shadowStatus` to see what WOULD have
+ *     happened. This is how teams roll out governance without the
+ *     political cost of enforcement.
  */
+export function evaluateGuard(
+  event: GuardEvent,
+  world: WorldDefinition,
+  options: GuardEngineOptions = {},
+): GuardVerdict {
+  const verdict = evaluateGuardCore(event, world, options);
+  return options.mode === 'observe' ? toShadowVerdict(verdict) : verdict;
+}
+
+/**
+ * Convert any non-ALLOW verdict to an ALLOW verdict with the original
+ * status preserved on `shadowStatus`. Idempotent — already-ALLOW verdicts
+ * pass through untouched (no shadow recorded because nothing was ever
+ * going to be blocked).
+ */
+function toShadowVerdict(verdict: GuardVerdict): GuardVerdict {
+  if (verdict.status === 'ALLOW') return verdict;
+  return {
+    ...verdict,
+    status: 'ALLOW',
+    shadowStatus: verdict.status,
+    shadowReason: verdict.reason,
+    // Preserve the original reason as shadowReason and wipe the
+    // top-level reason so callers that display `reason` for BLOCK/PAUSE
+    // don't accidentally surface an enforcement message.
+    reason: undefined,
+    warning: verdict.reason
+      ? `Observe mode: would have ${verdict.status.toLowerCase()} — ${verdict.reason}`
+      : `Observe mode: would have ${verdict.status.toLowerCase()}`,
+  };
+}
+
 // Maximum input length to prevent DoS via regex on large strings
 const MAX_INPUT_LENGTH = 100_000; // 100KB
 
-export function evaluateGuard(
+function evaluateGuardCore(
   event: GuardEvent,
   world: WorldDefinition,
   options: GuardEngineOptions = {},

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@
 // ─── Guard Engine ────────────────────────────────────────────────────────────
 
 export { evaluateGuard, eventToAllowlistKey, verdictToEvent } from './engine/guard-engine';
+export { auditBehavior, auditBehaviors } from './engine/audit-behavior';
+export type { AuditableEvent, Crossing } from './engine/audit-behavior';
 export { evaluateGuardWithAI } from './engine/ai-guard';
 export type { AIGuardOptions, AIGuardVerdict, IntentSource } from './engine/ai-guard';
 export { classifyIntentWithAI, extractContentFields } from './engine/intent-classifier';

--- a/src/radiant/commands/emergent.ts
+++ b/src/radiant/commands/emergent.ts
@@ -80,6 +80,13 @@ export interface EmergentResult {
   activeAdapters?: string[];
   /** World stack — what worlds were discovered and loaded. */
   worldStack?: WorldStack;
+  /**
+   * Governance audit — populated when a compiled world was loaded. Includes
+   * `crossings` (events that would have blocked/modified/paused in enforce
+   * mode) for surfacing in Bevia / Radiant UIs as moments the leader's
+   * worldmodel was bumped against.
+   */
+  governance?: GovernanceAudit;
 }
 
 // ─── Command ───────────────────────────────────────────────────────────────
@@ -287,6 +294,7 @@ export async function emergent(input: EmergentInput): Promise<EmergentResult> {
     eventCount: events.length,
     activeAdapters,
     worldStack,
+    governance,
   };
 }
 

--- a/src/radiant/core/governance.ts
+++ b/src/radiant/core/governance.ts
@@ -17,6 +17,7 @@ import { loadWorld } from '../../loader/world-loader';
 import type { WorldDefinition } from '../../types';
 import type { ClassifiedEvent } from '../core/signals';
 import type { ActorDomain } from '../core/domain';
+import type { Crossing } from '../../engine/audit-behavior';
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
@@ -34,6 +35,15 @@ export interface GovernanceAudit {
   human: { allow: number; modify: number; block: number; details: GovernanceVerdict[] };
   cyber: { allow: number; modify: number; block: number; details: GovernanceVerdict[] };
   joint: { allow: number; modify: number; block: number; details: GovernanceVerdict[] };
+  /**
+   * Crossings — events that WOULD have been blocked/paused/modified in
+   * enforce mode. Populated by running the guard engine in observe mode,
+   * so nothing is actually stopped; callers record the crossing for the
+   * leader to see. Each crossing carries shadowStatus + shadowReason so
+   * downstream tooling (Bevia, Radiant UIs, audit logs) can surface
+   * specific moments the worldmodel was touched.
+   */
+  crossings: Crossing[];
   /** Summary for rendering — most important findings. */
   summary: string;
 }
@@ -59,12 +69,17 @@ export async function auditGovernance(
   }
 
   const verdicts: GovernanceVerdict[] = [];
+  const crossings: Crossing[] = [];
 
   for (const ce of events) {
     const intent = ce.event.content?.slice(0, 500) || ce.event.kind || 'activity';
     const scope = (ce.event.metadata?.scope as string) || undefined;
 
     try {
+      // Observe mode — this evaluation is retroactive (the action
+      // already happened on GitHub). The engine must NOT attempt to
+      // enforce; it should report what WOULD have happened and let
+      // Bevia / Radiant surface the crossing to the leader.
       const result = evaluateGuard(
         {
           intent,
@@ -72,16 +87,36 @@ export async function auditGovernance(
           actionCategory: mapKindToCategory(ce.event.kind),
         },
         world,
+        { mode: 'observe' },
       );
+
+      // In observe mode `status` is always ALLOW. The real verdict
+      // lives on `shadowStatus` / `shadowReason`.
+      const shadow = result.shadowStatus ?? 'ALLOW';
 
       verdicts.push({
         eventId: ce.event.id,
         domain: ce.domain,
-        status: result.status as GovernanceVerdict['status'],
-        reason: result.reason,
+        status: shadow as GovernanceVerdict['status'],
+        reason: result.shadowReason,
         ruleId: result.ruleId,
         warning: result.warning,
       });
+
+      if (shadow !== 'ALLOW') {
+        crossings.push({
+          eventId: ce.event.id,
+          timestamp: ce.event.timestamp,
+          kind: ce.event.kind,
+          actorId: ce.event.actor.id,
+          shadowStatus: shadow,
+          shadowReason: result.shadowReason,
+          ruleId: result.ruleId,
+          excerpt: intent.length > 280 ? intent.slice(0, 279) + '…' : intent,
+          wouldHaveBlocked: true,
+          verdict: result,
+        });
+      }
     } catch {
       verdicts.push({
         eventId: ce.event.id,
@@ -104,6 +139,7 @@ export async function auditGovernance(
     human,
     cyber,
     joint,
+    crossings,
     summary,
   };
 }
@@ -180,6 +216,7 @@ function emptyAudit(total: number, reason: string): GovernanceAudit {
     human: { allow: 0, modify: 0, block: 0, details: [] },
     cyber: { allow: 0, modify: 0, block: 0, details: [] },
     joint: { allow: 0, modify: 0, block: 0, details: [] },
+    crossings: [],
     summary: reason,
   };
 }

--- a/test/observe-mode.test.ts
+++ b/test/observe-mode.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Observe Mode + auditBehavior tests.
+ *
+ * Verifies the two guarantees that callers rely on:
+ *
+ *   1. mode: 'observe' always returns ALLOW at the top level, even when
+ *      the real verdict would have been BLOCK / PAUSE / MODIFY / PENALIZE.
+ *      The original verdict is preserved on shadowStatus + shadowReason.
+ *
+ *   2. mode: 'enforce' (the default) returns exactly what it always did —
+ *      no regression for existing callers.
+ *
+ *   3. auditBehavior wraps observe-mode evaluation into a Crossing record
+ *      shaped for behavioral audit logs.
+ *
+ * We don't load a full world from disk — a minimal inline WorldDefinition
+ * with one blocking guard gives us everything we need.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { evaluateGuard } from '../src/engine/guard-engine';
+import { auditBehavior, auditBehaviors } from '../src/engine/audit-behavior';
+import type { WorldDefinition } from '../src/types';
+import type { GuardEvent } from '../src/contracts/guard-contract';
+
+// A minimal world: one guard that blocks any intent containing "delete".
+const world: WorldDefinition = {
+  world: {
+    id: 'test-observe',
+    name: 'Observe Mode Test World',
+    version: '1.0',
+    domain: 'test',
+    purpose: 'exercise observe mode without loading a fixture from disk',
+  },
+  invariants: [],
+  assumptions: { context: 'test', player_archetype: 'agent' },
+  stateSchema: { variables: [] },
+  rules: [],
+  gates: { stages: [] },
+  outcomes: { outcomes: [] },
+  guards: {
+    guards: [
+      {
+        id: 'no-delete',
+        label: 'No deletions',
+        description: 'Deletion intents are blocked',
+        category: 'structural',
+        enforcement: 'block',
+        immutable: true,
+        intent_patterns: ['delete'],
+      },
+    ],
+    intent_vocabulary: { delete: { label: 'Delete', pattern: 'delete' } },
+  },
+} as WorldDefinition;
+
+const deleteEvent: GuardEvent = { intent: 'delete all user data' };
+const benignEvent: GuardEvent = { intent: 'read configuration' };
+
+describe('evaluateGuard — enforce mode (default)', () => {
+  it('returns BLOCK for a matching intent', () => {
+    const verdict = evaluateGuard(deleteEvent, world);
+    expect(verdict.status).toBe('BLOCK');
+    expect(verdict.shadowStatus).toBeUndefined();
+  });
+
+  it('returns ALLOW for a benign intent', () => {
+    const verdict = evaluateGuard(benignEvent, world);
+    expect(verdict.status).toBe('ALLOW');
+    expect(verdict.shadowStatus).toBeUndefined();
+  });
+});
+
+describe('evaluateGuard — observe mode', () => {
+  it('coerces BLOCK → ALLOW and records shadowStatus', () => {
+    const verdict = evaluateGuard(deleteEvent, world, { mode: 'observe' });
+    expect(verdict.status).toBe('ALLOW');
+    expect(verdict.shadowStatus).toBe('BLOCK');
+    // Original reason moves to shadowReason; top-level reason is cleared
+    // so UIs that render `reason` for BLOCK/PAUSE don't accidentally
+    // surface an enforcement message.
+    expect(verdict.shadowReason).toBeDefined();
+    expect(verdict.reason).toBeUndefined();
+    // Warning flags observe-mode explicitly so logs are unambiguous.
+    expect(verdict.warning).toMatch(/Observe mode/i);
+  });
+
+  it('passes ALLOW verdicts through untouched', () => {
+    const verdict = evaluateGuard(benignEvent, world, { mode: 'observe' });
+    expect(verdict.status).toBe('ALLOW');
+    expect(verdict.shadowStatus).toBeUndefined();
+    expect(verdict.shadowReason).toBeUndefined();
+  });
+
+  it('preserves ruleId so callers know which rule crossed', () => {
+    const verdict = evaluateGuard(deleteEvent, world, { mode: 'observe' });
+    expect(verdict.ruleId).toBe('no-delete');
+  });
+});
+
+describe('auditBehavior', () => {
+  it('flags wouldHaveBlocked for a crossing event', () => {
+    const crossing = auditBehavior(
+      {
+        id: 'evt-1',
+        timestamp: '2026-04-18T09:00:00Z',
+        kind: 'commit',
+        content: 'delete the shared database',
+        actorId: 'alex',
+        actorKind: 'human',
+      },
+      world,
+    );
+    expect(crossing.wouldHaveBlocked).toBe(true);
+    expect(crossing.shadowStatus).toBe('BLOCK');
+    expect(crossing.ruleId).toBe('no-delete');
+    expect(crossing.excerpt).toBe('delete the shared database');
+  });
+
+  it('does not flag benign events', () => {
+    const crossing = auditBehavior(
+      {
+        id: 'evt-2',
+        timestamp: '2026-04-18T09:05:00Z',
+        kind: 'commit',
+        content: 'update the README',
+      },
+      world,
+    );
+    expect(crossing.wouldHaveBlocked).toBe(false);
+    expect(crossing.shadowStatus).toBe('ALLOW');
+  });
+
+  it('truncates long content in the excerpt', () => {
+    const content = 'delete ' + 'x'.repeat(1000);
+    const crossing = auditBehavior(
+      { id: 'e', timestamp: '2026-04-18T00:00:00Z', content },
+      world,
+    );
+    expect(crossing.excerpt?.length).toBeLessThanOrEqual(280);
+    expect(crossing.excerpt?.endsWith('…')).toBe(true);
+  });
+});
+
+describe('auditBehaviors', () => {
+  it('audits a stream and preserves ordering', () => {
+    const crossings = auditBehaviors(
+      [
+        { id: 'a', timestamp: '2026-04-18T00:00:00Z', content: 'delete x' },
+        { id: 'b', timestamp: '2026-04-18T00:00:01Z', content: 'read y' },
+        { id: 'c', timestamp: '2026-04-18T00:00:02Z', content: 'delete z' },
+      ],
+      world,
+    );
+    expect(crossings).toHaveLength(3);
+    expect(crossings.map((c) => c.wouldHaveBlocked)).toEqual([true, false, true]);
+    expect(crossings.map((c) => c.eventId)).toEqual(['a', 'b', 'c']);
+  });
+});


### PR DESCRIPTION
Engine-layer primitive for "measure behavior against your declared vision, without enforcing anything." Bevia's Mirror Mode, Radiant's CROSSINGS section, and any team that wants to roll out governance rule-by-rule all consume this.

New surface area:

  evaluateGuard(event, world, { mode: 'observe' })
    - Same evaluation, every layer runs identically
    - Non-ALLOW verdicts coerced to ALLOW at return time
    - Original status preserved on GuardVerdict.shadowStatus
    - Original reason preserved on GuardVerdict.shadowReason
    - Top-level `reason` wiped so UIs that display it for BLOCK/PAUSE don't leak enforcement language
    - warning field set to "Observe mode: would have <status>..." so audit logs read cleanly

  auditBehavior(event, world) / auditBehaviors(events, world)
    - Consume AuditableEvent (loose shape — commits, PRs, chat msgs)
    - Map to a synthetic GuardEvent (content → intent, kind → tool)
    - Call evaluateGuard in observe mode
    - Return Crossing records: eventId, timestamp, shadowStatus, shadowReason, ruleId, excerpt, wouldHaveBlocked, full verdict
    - Shaped for behavioral audit logs + Bevia dashboards

  neuroverse audit CLI
    - Observe-mode sibling of `neuroverse guard`
    - Always exits 0 (observe mode never blocks)
    - --multi to batch-evaluate a JSON array of events
    - --crossings-only to filter down to the interesting ones
    - Useful for replaying past activity against a new world to preview behavior before flipping to enforce

  Radiant auditGovernance → now emits crossings[]
    - Already ran evaluateGuard per classified event; switches to mode: 'observe' for semantic clarity (the events already happened — enforce mode is the wrong frame)
    - New GovernanceAudit.crossings field — Crossing[] for every event whose shadowStatus != ALLOW
    - EmergentResult now includes the full governance audit

Internal refactor: renamed the body of the public evaluateGuard to evaluateGuardCore (unexported), wrapped the public function in a thin observe-mode transform. Zero behavior change for existing callers — evaluateGuard(event, world) with no mode option returns exactly the same verdict as before.

Tests (test/observe-mode.test.ts):
  - enforce mode unchanged (regression guard)
  - observe mode coerces BLOCK → ALLOW + shadowStatus: BLOCK
  - observe mode passes ALLOW through untouched
  - ruleId preserved so callers know which rule crossed
  - auditBehavior wouldHaveBlocked flag correct for blocking and benign events
  - excerpt truncation at 280 chars with …
  - auditBehaviors preserves ordering

Version bump 0.10.0 → 0.11.0. CHANGELOG entry documents the full surface area and the non-breaking nature of the refactor.

Bevia inherits this once 0.11.0 is on npm + the radiant-run esm.sh import URL is bumped. Separate commit.