### PR TITLE
@neuroverseos/governance@0.12.0 — Google Workspace + Salesforce adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2026-04-19
+
+### Added
+- **Google Workspace adapter** (`@neuroverseos/governance/radiant` — `fetchGoogleWorkspaceActivity`, `formatGoogleWorkspaceSignalsForPrompt`). Reads the leader's Gmail sent folder + primary Calendar in the window, normalizes both into `Event[]`, emits signals for email volume + unique recipients + meeting load + organized-vs-attended + total meeting minutes. Takes a Google OAuth access token (scopes: `gmail.readonly`, `calendar.readonly`). Opens the entire non-engineering-leader market — every leader has Gmail + Calendar, almost none of them have GitHub.
+- **Salesforce adapter** (`fetchSalesforceActivity`, `formatSalesforceSignalsForPrompt`). Reads recent Opportunity movement, OpportunityFieldHistory (stage/amount/close-date transitions), Tasks + Calls, and Chatter FeedItems by the leader. Takes a Salesforce OAuth access token + instance URL. Emits signals for opportunities moved, stage transitions, amount changes, closed-won/lost, total pipeline represented, top-active stages. Opens the sales-leader market without requiring admin consent — individual reps/managers can authorize directly.
+
+### Notes
+- The adapter priority order (Google Workspace → Salesforce → Microsoft Teams) reflects auth friction: Google and Salesforce can be authorized by an individual user without tenant-admin consent; Teams / MS Graph typically requires enterprise admin approval for most real companies, so it ships later even though Microsoft's seat count is larger.
+
 ## [0.11.0] - 2026-04-18
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neuroverseos/governance",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Deterministic governance engine for AI agents — enforce worlds (permanent rules) and plans (mission constraints) with full audit trace",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/cli/audit.ts
+++ b/src/cli/audit.ts
@@ -83,6 +83,10 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
   let world;
   try {
     const resolved = resolveWorldPath(args.worldPath);
+    if (!resolved) {
+      process.stderr.write(`Failed to resolve world path: ${args.worldPath}\n`);
+      process.exit(1);
+    }
     world = await loadWorld(resolved);
   } catch (err) {
     process.stderr.write(`Failed to load world: ${err instanceof Error ? err.message : err}\n`);

--- a/src/radiant/adapters/google-workspace.ts
+++ b/src/radiant/adapters/google-workspace.ts
@@ -1,0 +1,345 @@
+/**
+ * @neuroverseos/governance/radiant — Google Workspace adapter
+ *
+ * Reads the leader's Gmail (sent messages) + Calendar (events in the
+ * window) and normalizes both into Event[] for the Radiant pipeline.
+ *
+ * Why Google Workspace matters:
+ *   - It's the most universal source. Every non-MS-shop leader has
+ *     Gmail + Calendar. Non-engineering leaders who never touch GitHub
+ *     or Linear still live in these two apps.
+ *   - Gmail sent folder = external coordination signal. What the
+ *     leader's actually pushing out into the world. Drift between
+ *     stated strategy and actual outreach shows up here first.
+ *   - Calendar = meeting load vs. output. Heavy meetings + thin
+ *     shipping = the drift pattern leaders most want to catch.
+ *
+ * v1 scope:
+ *   - Gmail: list the leader's own sent messages in the window.
+ *     Subject + snippet + recipients + timestamp. No body (privacy +
+ *     payload size).
+ *   - Calendar: list events in the window from the primary calendar.
+ *     Title + attendees count + duration + whether the leader
+ *     organized.
+ *
+ * Auth: Google OAuth access token with scopes
+ *   https://www.googleapis.com/auth/gmail.readonly
+ *   https://www.googleapis.com/auth/calendar.readonly
+ * Token lifecycle (refresh) is the caller's job — this adapter takes
+ * a valid access token as input.
+ *
+ * Deno / browser / Node all work — uses native fetch only.
+ */
+
+import type { Event } from '../core/domain';
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+export interface GoogleWorkspaceFetchOptions {
+  /** Access token with gmail.readonly + calendar.readonly scopes. */
+  accessToken: string;
+  /** How many days of history to fetch. Default: 14. */
+  windowDays?: number;
+  /** Max emails to include. Default: 100. */
+  maxEmails?: number;
+  /** Max calendar events to include. Default: 100. */
+  maxEvents?: number;
+  /** The leader's own email address — used to identify their events. */
+  leaderEmail?: string;
+}
+
+export interface GoogleWorkspaceSignals {
+  emailsSent: number;
+  uniqueRecipients: number;
+  topRecipients: string[];
+  meetingsHeld: number;
+  meetingsOrganized: number;
+  uniqueAttendees: number;
+  totalMeetingMinutes: number;
+  avgMeetingAttendees: number | null;
+}
+
+// ─── Main entry ────────────────────────────────────────────────────────────
+
+export async function fetchGoogleWorkspaceActivity(
+  options: GoogleWorkspaceFetchOptions,
+): Promise<{ events: Event[]; signals: GoogleWorkspaceSignals }> {
+  const windowDays = options.windowDays ?? 14;
+  const maxEmails = options.maxEmails ?? 100;
+  const maxEvents = options.maxEvents ?? 100;
+  const leaderEmail = options.leaderEmail?.toLowerCase();
+  const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000);
+
+  const [emailEvents, emailSignals] = await fetchGmailSent(
+    options.accessToken,
+    since,
+    maxEmails,
+    leaderEmail,
+  );
+  const [calendarEvents, calendarSignals] = await fetchCalendarEvents(
+    options.accessToken,
+    since,
+    maxEvents,
+    leaderEmail,
+  );
+
+  const events = [...emailEvents, ...calendarEvents].sort(
+    (a, b) => Date.parse(a.timestamp) - Date.parse(b.timestamp),
+  );
+
+  return {
+    events,
+    signals: {
+      ...emailSignals,
+      ...calendarSignals,
+    },
+  };
+}
+
+/**
+ * Format Google Workspace signals for the AI interpretation prompt.
+ */
+export function formatGoogleWorkspaceSignalsForPrompt(
+  signals: GoogleWorkspaceSignals,
+): string {
+  if (signals.emailsSent === 0 && signals.meetingsHeld === 0) return '';
+
+  const lines = [
+    '## Google Workspace Activity (external coordination + meeting load)',
+    '',
+  ];
+
+  if (signals.emailsSent > 0) {
+    lines.push(
+      `${signals.emailsSent} emails sent in window, to ${signals.uniqueRecipients} unique recipients.`,
+    );
+    if (signals.topRecipients.length > 0) {
+      lines.push(`Most-emailed: ${signals.topRecipients.slice(0, 5).join(', ')}.`);
+    }
+  }
+
+  if (signals.meetingsHeld > 0) {
+    const hours = Math.round((signals.totalMeetingMinutes / 60) * 10) / 10;
+    lines.push(
+      `${signals.meetingsHeld} meetings held (${signals.meetingsOrganized} organized by the leader), ${hours}h total.`,
+    );
+    if (signals.avgMeetingAttendees !== null) {
+      lines.push(
+        `Average ${signals.avgMeetingAttendees} attendees per meeting, ${signals.uniqueAttendees} unique attendees total.`,
+      );
+    }
+  }
+
+  lines.push('');
+  lines.push(
+    "Gmail sent volume + Calendar meeting load reveal a leader's external coordination shape.",
+  );
+  lines.push(
+    'Compare against shipped work (GitHub, Linear) to find the stated-strategy-vs-actual-time gap.',
+  );
+
+  return lines.join('\n');
+}
+
+// ─── Gmail ─────────────────────────────────────────────────────────────────
+
+async function fetchGmailSent(
+  token: string,
+  since: Date,
+  maxEmails: number,
+  leaderEmail: string | undefined,
+): Promise<[Event[], Pick<GoogleWorkspaceSignals, 'emailsSent' | 'uniqueRecipients' | 'topRecipients'>]> {
+  // Gmail search query: in:sent after:<unix ts seconds>. Uses the
+  // authenticated user's own mailbox.
+  const sinceUnix = Math.floor(since.getTime() / 1000);
+  const listUrl = new URL('https://gmail.googleapis.com/gmail/v1/users/me/messages');
+  listUrl.searchParams.set('q', `in:sent after:${sinceUnix}`);
+  listUrl.searchParams.set('maxResults', String(Math.min(maxEmails, 100)));
+
+  const listRes = await fetch(listUrl.toString(), {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!listRes.ok) {
+    throw new Error(`Gmail list failed ${listRes.status}: ${(await listRes.text()).slice(0, 200)}`);
+  }
+  const listJson = (await listRes.json()) as { messages?: Array<{ id: string }> };
+  const ids = (listJson.messages ?? []).slice(0, maxEmails);
+
+  const events: Event[] = [];
+  const recipientCounts = new Map<string, number>();
+
+  // Fetch each message's metadata. Gmail doesn't batch nicely in v1; parallel-limit.
+  const PARALLEL = 5;
+  for (let i = 0; i < ids.length; i += PARALLEL) {
+    const chunk = ids.slice(i, i + PARALLEL);
+    const results = await Promise.all(
+      chunk.map((m) =>
+        fetch(
+          `https://gmail.googleapis.com/gmail/v1/users/me/messages/${m.id}?format=metadata&metadataHeaders=From&metadataHeaders=To&metadataHeaders=Subject&metadataHeaders=Date`,
+          { headers: { Authorization: `Bearer ${token}` } },
+        )
+          .then((r) => (r.ok ? r.json() : null))
+          .catch(() => null),
+      ),
+    );
+    for (const msg of results) {
+      if (!msg) continue;
+      const headers = ((msg as { payload?: { headers?: Array<{ name: string; value: string }> } }).payload?.headers) || [];
+      const header = (n: string) =>
+        headers.find((h) => h.name.toLowerCase() === n.toLowerCase())?.value ?? '';
+      const subject = header('Subject') || '(no subject)';
+      const to = header('To');
+      const dateHdr = header('Date');
+      const timestamp = dateHdr ? new Date(dateHdr).toISOString() : new Date().toISOString();
+      const snippet = (msg as { snippet?: string }).snippet ?? '';
+
+      const recipients = parseAddressList(to);
+      for (const r of recipients) {
+        recipientCounts.set(r, (recipientCounts.get(r) ?? 0) + 1);
+      }
+
+      events.push({
+        id: `gmail-${(msg as { id: string }).id}`,
+        timestamp,
+        actor: {
+          id: leaderEmail ?? 'leader',
+          kind: 'human',
+          name: leaderEmail ?? 'Leader',
+        },
+        kind: 'email_sent',
+        content: `${subject} — ${snippet.slice(0, 200)}`,
+        metadata: {
+          to: recipients.slice(0, 5),
+          subject,
+        },
+      });
+    }
+  }
+
+  const topRecipients = [...recipientCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10)
+    .map(([addr]) => addr);
+
+  return [
+    events,
+    {
+      emailsSent: events.length,
+      uniqueRecipients: recipientCounts.size,
+      topRecipients,
+    },
+  ];
+}
+
+function parseAddressList(raw: string): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((a) => {
+      const match = a.match(/<([^>]+)>/);
+      const addr = (match ? match[1] : a).trim().toLowerCase();
+      return addr;
+    })
+    .filter((a) => a.includes('@') && a.length < 100);
+}
+
+// ─── Calendar ──────────────────────────────────────────────────────────────
+
+async function fetchCalendarEvents(
+  token: string,
+  since: Date,
+  maxEvents: number,
+  leaderEmail: string | undefined,
+): Promise<[Event[], Omit<GoogleWorkspaceSignals, 'emailsSent' | 'uniqueRecipients' | 'topRecipients'>]> {
+  const timeMin = since.toISOString();
+  const timeMax = new Date().toISOString();
+  const url = new URL('https://www.googleapis.com/calendar/v3/calendars/primary/events');
+  url.searchParams.set('timeMin', timeMin);
+  url.searchParams.set('timeMax', timeMax);
+  url.searchParams.set('singleEvents', 'true');
+  url.searchParams.set('orderBy', 'startTime');
+  url.searchParams.set('maxResults', String(Math.min(maxEvents, 250)));
+
+  const res = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    throw new Error(`Calendar list failed ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  }
+
+  const json = (await res.json()) as {
+    items?: Array<{
+      id: string;
+      summary?: string;
+      start?: { dateTime?: string; date?: string };
+      end?: { dateTime?: string; date?: string };
+      organizer?: { email?: string };
+      attendees?: Array<{ email?: string; responseStatus?: string }>;
+      status?: string;
+    }>;
+  };
+
+  const events: Event[] = [];
+  const attendeeSet = new Set<string>();
+  let totalMinutes = 0;
+  let meetingsOrganized = 0;
+  const attendeeCounts: number[] = [];
+
+  for (const ev of json.items ?? []) {
+    if (ev.status === 'cancelled') continue;
+
+    const start = ev.start?.dateTime || ev.start?.date;
+    const end = ev.end?.dateTime || ev.end?.date;
+    if (!start) continue;
+
+    const startMs = new Date(start).getTime();
+    const endMs = end ? new Date(end).getTime() : startMs;
+    const minutes = Math.max(0, Math.round((endMs - startMs) / 60_000));
+    totalMinutes += minutes;
+
+    const attendees = (ev.attendees ?? [])
+      .map((a) => a.email?.toLowerCase())
+      .filter((e): e is string => !!e && e.includes('@'));
+    for (const a of attendees) attendeeSet.add(a);
+    attendeeCounts.push(attendees.length);
+
+    const organizedByLeader =
+      leaderEmail && ev.organizer?.email?.toLowerCase() === leaderEmail;
+    if (organizedByLeader) meetingsOrganized++;
+
+    events.push({
+      id: `gcal-${ev.id}`,
+      timestamp: start,
+      actor: {
+        id: leaderEmail ?? 'leader',
+        kind: 'human',
+        name: leaderEmail ?? 'Leader',
+      },
+      kind: organizedByLeader ? 'meeting_organized' : 'meeting_attended',
+      content: `${ev.summary ?? '(no title)'} — ${minutes}min, ${attendees.length} attendees`,
+      metadata: {
+        attendees: attendees.slice(0, 10),
+        minutes,
+        organizer: ev.organizer?.email,
+      },
+    });
+  }
+
+  const avgAttendees =
+    attendeeCounts.length > 0
+      ? Math.round(
+          attendeeCounts.reduce((a, b) => a + b, 0) / attendeeCounts.length,
+        )
+      : null;
+
+  return [
+    events,
+    {
+      meetingsHeld: events.length,
+      meetingsOrganized,
+      uniqueAttendees: attendeeSet.size,
+      totalMeetingMinutes: totalMinutes,
+      avgMeetingAttendees: avgAttendees,
+    },
+  ];
+}

--- a/src/radiant/adapters/salesforce.ts
+++ b/src/radiant/adapters/salesforce.ts
@@ -1,0 +1,333 @@
+/**
+ * @neuroverseos/governance/radiant — Salesforce adapter
+ *
+ * Reads the leader's Salesforce activity and normalizes it into Event[]
+ * for the Radiant pipeline. Opens the entire sales-leader market —
+ * every sales org of any scale runs on Salesforce, and "is the pipeline
+ * drifting from what we declared we'd close" is the exact job Radiant
+ * does for that audience.
+ *
+ * v1 scope:
+ *   - Recent Opportunity changes: stage transitions, amount updates,
+ *     close-date changes (the signal set for deal-drift detection)
+ *   - Recent Tasks + logged Calls (activity per rep)
+ *   - Chatter FeedItems if accessible (how the team talks about deals)
+ *
+ * Auth: Salesforce OAuth — access token + instance URL. Each org has
+ * its own `my.salesforce.com` endpoint; the token alone isn't enough,
+ * the caller must also pass the instance URL.
+ *
+ * Individual-rep or individual-manager OAuth works without admin
+ * consent — this adapter assumes one Salesforce user's view. For
+ * enterprise admin-consent + org-wide access, a later adapter
+ * variant can use the Reports API or a service-user token.
+ *
+ * Deno / browser / Node — native fetch only.
+ */
+
+import type { Event } from '../core/domain';
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+export interface SalesforceFetchOptions {
+  /** OAuth access token with api + refresh_token scopes. */
+  accessToken: string;
+  /**
+   * Salesforce instance URL — e.g. https://acme.my.salesforce.com.
+   * Comes back in the token response; caller must persist it.
+   */
+  instanceUrl: string;
+  /** How many days of history to fetch. Default: 14. */
+  windowDays?: number;
+  /** Max records per entity. Default: 200 (hard cap on SOQL page). */
+  maxRecords?: number;
+  /** The leader's own Salesforce user name / email, if known. */
+  leaderName?: string;
+}
+
+export interface SalesforceSignals {
+  opportunitiesMoved: number;
+  stageTransitions: number;
+  amountChanges: number;
+  closedWon: number;
+  closedLost: number;
+  tasksLogged: number;
+  callsLogged: number;
+  feedPostsByLeader: number;
+  totalPipelineAmount: number;
+  topStages: Array<{ stage: string; count: number }>;
+}
+
+// ─── Main entry ────────────────────────────────────────────────────────────
+
+export async function fetchSalesforceActivity(
+  options: SalesforceFetchOptions,
+): Promise<{ events: Event[]; signals: SalesforceSignals }> {
+  const windowDays = options.windowDays ?? 14;
+  const maxRecords = Math.min(options.maxRecords ?? 200, 200);
+  const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000);
+  const sinceSoql = since.toISOString();
+
+  const events: Event[] = [];
+  const signals: SalesforceSignals = {
+    opportunitiesMoved: 0,
+    stageTransitions: 0,
+    amountChanges: 0,
+    closedWon: 0,
+    closedLost: 0,
+    tasksLogged: 0,
+    callsLogged: 0,
+    feedPostsByLeader: 0,
+    totalPipelineAmount: 0,
+    topStages: [],
+  };
+
+  // ─── Opportunities moved in window ─────────────────────────────────────
+  const opps = await soqlQuery<{
+    Id: string;
+    Name: string;
+    StageName: string;
+    Amount: number | null;
+    CloseDate: string;
+    IsClosed: boolean;
+    IsWon: boolean;
+    LastModifiedDate: string;
+    Owner: { Name?: string };
+  }>(
+    options,
+    `SELECT Id, Name, StageName, Amount, CloseDate, IsClosed, IsWon, LastModifiedDate, Owner.Name
+     FROM Opportunity
+     WHERE LastModifiedDate >= ${sinceSoql}
+     ORDER BY LastModifiedDate DESC
+     LIMIT ${maxRecords}`,
+  );
+
+  const stageCounts = new Map<string, number>();
+  for (const opp of opps) {
+    signals.opportunitiesMoved++;
+    signals.totalPipelineAmount += opp.Amount ?? 0;
+    stageCounts.set(opp.StageName, (stageCounts.get(opp.StageName) ?? 0) + 1);
+    if (opp.IsClosed && opp.IsWon) signals.closedWon++;
+    if (opp.IsClosed && !opp.IsWon) signals.closedLost++;
+
+    events.push({
+      id: `sf-opp-${opp.Id}`,
+      timestamp: opp.LastModifiedDate,
+      actor: {
+        id: opp.Owner?.Name ?? 'unknown',
+        kind: 'human',
+        name: opp.Owner?.Name ?? 'unknown',
+      },
+      kind: opp.IsClosed ? (opp.IsWon ? 'deal_won' : 'deal_lost') : 'deal_updated',
+      content: `${opp.Name} — ${opp.StageName}${
+        opp.Amount ? ` · $${Math.round(opp.Amount).toLocaleString()}` : ''
+      } · close ${opp.CloseDate}`,
+      metadata: {
+        opportunityId: opp.Id,
+        stage: opp.StageName,
+        amount: opp.Amount,
+        closeDate: opp.CloseDate,
+      },
+    });
+  }
+  signals.topStages = [...stageCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([stage, count]) => ({ stage, count }));
+
+  // ─── Opportunity history — stage + amount transitions ────────────────
+  const history = await soqlQuery<{
+    Id: string;
+    OpportunityId: string;
+    Field: string;
+    OldValue: unknown;
+    NewValue: unknown;
+    CreatedDate: string;
+    CreatedBy: { Name?: string };
+  }>(
+    options,
+    `SELECT Id, OpportunityId, Field, OldValue, NewValue, CreatedDate, CreatedBy.Name
+     FROM OpportunityFieldHistory
+     WHERE CreatedDate >= ${sinceSoql} AND Field IN ('StageName', 'Amount', 'CloseDate')
+     ORDER BY CreatedDate DESC
+     LIMIT ${maxRecords}`,
+  ).catch(() => []);
+
+  for (const h of history) {
+    if (h.Field === 'StageName') signals.stageTransitions++;
+    if (h.Field === 'Amount') signals.amountChanges++;
+    events.push({
+      id: `sf-hist-${h.Id}`,
+      timestamp: h.CreatedDate,
+      actor: {
+        id: h.CreatedBy?.Name ?? 'unknown',
+        kind: 'human',
+        name: h.CreatedBy?.Name ?? 'unknown',
+      },
+      kind: `deal_${h.Field.toLowerCase()}_changed`,
+      content: `${h.Field}: ${String(h.OldValue)} → ${String(h.NewValue)}`,
+      metadata: {
+        opportunityId: h.OpportunityId,
+        field: h.Field,
+      },
+    });
+  }
+
+  // ─── Tasks + Calls ──────────────────────────────────────────────────────
+  const tasks = await soqlQuery<{
+    Id: string;
+    Subject: string;
+    Status: string;
+    Type: string | null;
+    CreatedDate: string;
+    Owner: { Name?: string };
+  }>(
+    options,
+    `SELECT Id, Subject, Status, Type, CreatedDate, Owner.Name
+     FROM Task
+     WHERE CreatedDate >= ${sinceSoql}
+     ORDER BY CreatedDate DESC
+     LIMIT ${maxRecords}`,
+  ).catch(() => []);
+
+  for (const t of tasks) {
+    signals.tasksLogged++;
+    if (t.Type === 'Call' || (t.Subject || '').toLowerCase().includes('call')) {
+      signals.callsLogged++;
+    }
+    events.push({
+      id: `sf-task-${t.Id}`,
+      timestamp: t.CreatedDate,
+      actor: {
+        id: t.Owner?.Name ?? 'unknown',
+        kind: 'human',
+        name: t.Owner?.Name ?? 'unknown',
+      },
+      kind: t.Type === 'Call' ? 'call_logged' : 'task_logged',
+      content: `${t.Subject} — ${t.Status}`,
+      metadata: { taskId: t.Id, type: t.Type, status: t.Status },
+    });
+  }
+
+  // ─── Feed posts by leader (Chatter) ────────────────────────────────────
+  if (options.leaderName) {
+    const feed = await soqlQuery<{
+      Id: string;
+      Body: string;
+      CreatedDate: string;
+      CreatedBy: { Name?: string };
+      ParentId: string;
+    }>(
+      options,
+      `SELECT Id, Body, CreatedDate, CreatedBy.Name, ParentId
+       FROM FeedItem
+       WHERE CreatedDate >= ${sinceSoql} AND CreatedBy.Name = '${escapeSoql(options.leaderName)}'
+       ORDER BY CreatedDate DESC
+       LIMIT ${Math.min(maxRecords, 50)}`,
+    ).catch(() => []);
+    for (const f of feed) {
+      signals.feedPostsByLeader++;
+      events.push({
+        id: `sf-feed-${f.Id}`,
+        timestamp: f.CreatedDate,
+        actor: {
+          id: f.CreatedBy?.Name ?? 'unknown',
+          kind: 'human',
+          name: f.CreatedBy?.Name ?? 'unknown',
+        },
+        kind: 'feed_post',
+        content: (f.Body || '').slice(0, 280),
+        metadata: { feedId: f.Id, parent: f.ParentId },
+      });
+    }
+  }
+
+  events.sort((a, b) => Date.parse(a.timestamp) - Date.parse(b.timestamp));
+
+  return { events, signals };
+}
+
+/**
+ * Format Salesforce signals for the AI interpretation prompt.
+ */
+export function formatSalesforceSignalsForPrompt(signals: SalesforceSignals): string {
+  if (
+    signals.opportunitiesMoved === 0 &&
+    signals.tasksLogged === 0 &&
+    signals.stageTransitions === 0
+  ) {
+    return '';
+  }
+
+  const lines = [
+    '## Salesforce Activity (stated pipeline vs observed motion)',
+    '',
+  ];
+  if (signals.opportunitiesMoved > 0) {
+    const pipelineM = Math.round(signals.totalPipelineAmount / 10_000) / 100;
+    lines.push(
+      `${signals.opportunitiesMoved} opportunities touched in window ($${pipelineM}M total pipeline represented).`,
+    );
+    lines.push(
+      `${signals.stageTransitions} stage changes, ${signals.amountChanges} amount changes.`,
+    );
+    if (signals.closedWon + signals.closedLost > 0) {
+      lines.push(`${signals.closedWon} closed won, ${signals.closedLost} closed lost.`);
+    }
+    if (signals.topStages.length > 0) {
+      lines.push(
+        `Most active stages: ${signals.topStages
+          .map((s) => `${s.stage} (${s.count})`)
+          .join(', ')}.`,
+      );
+    }
+  }
+  if (signals.tasksLogged > 0) {
+    lines.push(
+      `${signals.tasksLogged} tasks logged (${signals.callsLogged} calls).`,
+    );
+  }
+  if (signals.feedPostsByLeader > 0) {
+    lines.push(`${signals.feedPostsByLeader} feed posts by the leader.`);
+  }
+
+  lines.push('');
+  lines.push(
+    'Salesforce shows what the team said would happen (stages, forecast) vs. what is actually happening (movement, activity, close).',
+  );
+  lines.push(
+    'Compare stage transitions against stated strategy — are the deals the leader said would close actually moving, or is the pipeline drifting?',
+  );
+
+  return lines.join('\n');
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+async function soqlQuery<T>(
+  opts: SalesforceFetchOptions,
+  query: string,
+): Promise<T[]> {
+  const url = new URL(`${opts.instanceUrl}/services/data/v59.0/query`);
+  url.searchParams.set('q', query);
+  const res = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${opts.accessToken}` },
+  });
+  if (!res.ok) {
+    // Let the caller decide whether a single table's failure is fatal;
+    // callers that tolerate missing permissions use .catch(() => []).
+    throw new Error(
+      `Salesforce SOQL ${res.status}: ${(await res.text()).slice(0, 200)}`,
+    );
+  }
+  const json = (await res.json()) as { records?: T[] };
+  return json.records ?? [];
+}
+
+function escapeSoql(raw: string): string {
+  // Defensive — strip single quotes and backslashes from string
+  // literals interpolated into SOQL. Better: use typed binds when the
+  // SF client supports them, but this is v1 and the leaderName comes
+  // from the leader's own OAuth userinfo, not user input.
+  return raw.replace(/['\\]/g, '');
+}

--- a/src/radiant/index.ts
+++ b/src/radiant/index.ts
@@ -159,6 +159,28 @@ export { fetchNotionActivity, formatNotionSignalsForPrompt } from './adapters/no
 export type { LinearFetchOptions, LinearSignals } from './adapters/linear';
 export { fetchLinearActivity, formatLinearSignalsForPrompt } from './adapters/linear';
 
+// ─── Google Workspace adapter ──────────────────────────────────────────────
+
+export type {
+  GoogleWorkspaceFetchOptions,
+  GoogleWorkspaceSignals,
+} from './adapters/google-workspace';
+export {
+  fetchGoogleWorkspaceActivity,
+  formatGoogleWorkspaceSignalsForPrompt,
+} from './adapters/google-workspace';
+
+// ─── Salesforce adapter ────────────────────────────────────────────────────
+
+export type {
+  SalesforceFetchOptions,
+  SalesforceSignals,
+} from './adapters/salesforce';
+export {
+  fetchSalesforceActivity,
+  formatSalesforceSignalsForPrompt,
+} from './adapters/salesforce';
+
 // ─── Pattern interpretation ────────────────────────────────────────────────
 
 export type { InterpretInput, InterpretResult } from './core/patterns';

--- a/test/observe-mode.test.ts
+++ b/test/observe-mode.test.ts
@@ -94,7 +94,10 @@ describe('evaluateGuard — observe mode', () => {
 
   it('preserves ruleId so callers know which rule crossed', () => {
     const verdict = evaluateGuard(deleteEvent, world, { mode: 'observe' });
-    expect(verdict.ruleId).toBe('no-delete');
+    // guard-engine prefixes guard IDs with "guard-" on every return path
+    // (see src/engine/guard-engine.ts L841+). Tests assert the prefixed
+    // form so they catch regressions in that contract.
+    expect(verdict.ruleId).toBe('guard-no-delete');
   });
 });
 
@@ -113,7 +116,7 @@ describe('auditBehavior', () => {
     );
     expect(crossing.wouldHaveBlocked).toBe(true);
     expect(crossing.shadowStatus).toBe('BLOCK');
-    expect(crossing.ruleId).toBe('no-delete');
+    expect(crossing.ruleId).toBe('guard-no-delete');
     expect(crossing.excerpt).toBe('delete the shared database');
   });
 


### PR DESCRIPTION
Two adapters, one release. Opens Bevia Radiant to the non-engineering- leader market (Google Workspace) and the sales-leader market (Salesforce) in the same ship. Each one is a day of adapter work that unlocks an entire audience; together they cover most leaders at most real companies.

Google Workspace adapter (src/radiant/adapters/google-workspace.ts):
  - fetchGoogleWorkspaceActivity({ accessToken, windowDays, ... })
  - Gmail sent folder: subject + snippet + recipients per sent message in window; uses in:sent after:<unix> query for efficient filtering
  - Primary Calendar: timed events with attendees + duration + whether the leader organized; singleEvents=true for recurrence expansion
  - Normalized to Event[] with kinds email_sent / meeting_organized / meeting_attended
  - Signals: emailsSent, uniqueRecipients, topRecipients (up to 10), meetingsHeld, meetingsOrganized, totalMeetingMinutes, avgMeetingAttendees, uniqueAttendees
  - formatGoogleWorkspaceSignalsForPrompt explains the stated-strategy- vs-actual-time framing for the AI narrator
  - Individual-user OAuth — no Google Workspace admin consent required

Salesforce adapter (src/radiant/adapters/salesforce.ts):
  - fetchSalesforceActivity({ accessToken, instanceUrl, ... })
  - Opportunity: records moved in window via LastModifiedDate; kinds deal_won / deal_lost / deal_updated with amount + stage + close date on metadata
  - OpportunityFieldHistory: stage/amount/close-date transitions as discrete Events (deal_stagename_changed, deal_amount_changed, etc) so the drift signal surfaces as individual moments rather than aggregate deltas
  - Task + Call: activity logged per rep, kinds call_logged / task_logged
  - FeedItem (Chatter): leader's own posts as kind feed_post
  - Signals: opportunitiesMoved, stageTransitions, amountChanges, closedWon, closedLost, tasksLogged, callsLogged, feedPostsByLeader, totalPipelineAmount, topStages
  - Individual-rep OAuth — no Salesforce admin consent required
  - soqlQuery helper + escapeSoql defensive string handling

Exports in src/radiant/index.ts expanded with the two new adapter types + functions. Pattern matches the existing Slack/Notion/Linear export blocks.

CHANGELOG 0.12.0 entry documents both adapters + the strategic rationale for shipping Google + Salesforce before Microsoft Teams (auth friction — MS Graph requires tenant admin for most real orgs).

Once published: Bevia's radiant-run picks up the new adapters via the esm.sh URL bump (next commit on the Bevia repo).