### PR TITLE
Sync package-lock.json to 0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neuroverseos/governance",
-  "version": "0.9.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neuroverseos/governance",
-      "version": "0.9.0",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "bin": {
         "neuroverse": "dist/cli/neuroverse.js"


### PR DESCRIPTION
Lockfile was stale — recorded version 0.9.0 while package.json had been bumped to 0.12.0 across the 0.10 / 0.11 / 0.12 releases. Anyone doing npm ci would install against a mismatched tree. Picked up by an npm install pre-publish.

https://claude.ai/code/session_company-intelligence-research-SOzr6